### PR TITLE
Refactor Nix package generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - ./CardanoCSL.hs --help
   - ./TimeWarp.hs --help
   - ./Infra.hs --help
-  - nix-instantiate default.nix -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/4281374b8d3a3aabbb08f4aad042ec7a81794db9.tar.gz
+  - nix-instantiate default.nix -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/763e21e982370f67c126f92a1113ea949db3b6e0.tar.gz
   - nixops deploy -d csl --evaluate-only
   - nixops deploy -d tw --evaluate-only
   - nixops deploy -d inf --evaluate-only

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,3 @@
 { pkgs ? (import <nixpkgs> {}), ... }:
 
-(import ./srk-nixpkgs.nix { 
-    inherit pkgs; 
-    inherit (import ./config.nix) genesisN slotDuration networkDiameter mpcRelayInterval;
-}).hspkgs.cardano-sl
+(import ./srk-nixpkgs.nix { inherit pkgs;}).hspkgs.cardano-sl-static

--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -7,7 +7,7 @@ let
   node0 = nodes.node0.config;
   name = "cardano-node";
   stateDir = "/var/lib/cardano-node/";
-  cardano = (import ./../srk-nixpkgs.nix { inherit pkgs; inherit (cfg) genesisN slotDuration networkDiameter mpcRelayInterval; }).hspkgs.cardano-sl;
+  cardano = (import ./../srk-nixpkgs.nix { inherit pkgs; }).hspkgs.cardano-sl-static;
   distributionParam = "(${toString cfg.genesisN},${toString cfg.totalMoneyAmount})";
   enableIf = cond: flag: if cond then flag else "";
   smartGenIP = builtins.getEnv "SMART_GEN_IP";

--- a/pkgs/acid-state.nix
+++ b/pkgs/acid-state.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, array, base, bytestring, cereal, containers
+, directory, extensible-exceptions, fetchgit, filepath, mtl
+, network, safecopy, stdenv, stm, template-haskell, th-expand-syns
+, unix
+}:
+mkDerivation {
+  pname = "acid-state";
+  version = "0.14.2";
+  src = fetchgit {
+    url = "https://github.com/serokell/acid-state.git";
+    sha256 = "109liqzk66cxkarw8r8jxh27n6qzdcha2xlhsj56xzyqc2aqjz15";
+    rev = "95fce1dbada62020a0b2d6aa2dd7e88eadd7214b";
+  };
+  libraryHaskellDepends = [
+    array base bytestring cereal containers directory
+    extensible-exceptions filepath mtl network safecopy stm
+    template-haskell th-expand-syns unix
+  ];
+  homepage = "http://acid-state.seize.it/";
+  description = "Add ACID guarantees to any serializable Haskell data structure";
+  license = stdenv.lib.licenses.publicDomain;
+}

--- a/pkgs/cardano-crypto.nix
+++ b/pkgs/cardano-crypto.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, base, bytestring, cryptonite, cryptonite-openssl
+, deepseq, fetchgit, hashable, memory, stdenv, tasty
+, tasty-quickcheck
+}:
+mkDerivation {
+  pname = "cardano-crypto";
+  version = "1.0.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/cardano-crypto";
+    sha256 = "02gjaj7889y30g2qfdh96ywrsdpmgfgyqyajw49zaklwjvkh87sv";
+    rev = "838b064d8a59286142aa2fe14434fe7601896ddb";
+  };
+  libraryHaskellDepends = [
+    base bytestring cryptonite cryptonite-openssl deepseq hashable
+    memory
+  ];
+  testHaskellDepends = [
+    base bytestring cryptonite memory tasty tasty-quickcheck
+  ];
+  doCheck = false;
+  homepage = "https://github.com/input-output-hk/cardano-crypto#readme";
+  description = "Cryptography primitives for cardano";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/cardano-report-server.nix
+++ b/pkgs/cardano-report-server.nix
@@ -1,0 +1,38 @@
+{ mkDerivation, aeson, aeson-pretty, base, bytestring
+, case-insensitive, directory, exceptions, fetchgit, filelock
+, filepath, formatting, hspec, http-types, HUnit, lens, lifted-base
+, log-warper, monad-control, mtl, network, optparse-applicative
+, optparse-simple, parsec, QuickCheck, quickcheck-text, random
+, scotty, stdenv, text, time, transformers, universum, vector, wai
+, wai-extra, warp
+}:
+mkDerivation {
+  pname = "cardano-report-server";
+  version = "0.1.2";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/cardano-report-server.git";
+    sha256 = "11wq4wjp45mn45x3109xi64p824mlimjkd4dk6r7gnmd0l9v77mh";
+    rev = "424e4ecacdf038a01542025dd1296bd272ce770d";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson aeson-pretty base bytestring case-insensitive directory
+    exceptions filelock filepath formatting http-types lens lifted-base
+    log-warper monad-control mtl network optparse-applicative
+    optparse-simple parsec random scotty text time transformers
+    universum vector wai wai-extra warp
+  ];
+  executableHaskellDepends = [
+    base directory filepath http-types log-warper monad-control mtl
+    optparse-applicative optparse-simple parsec random scotty universum
+    wai-extra warp
+  ];
+  testHaskellDepends = [
+    aeson base hspec HUnit lens QuickCheck quickcheck-text text time
+    transformers universum
+  ];
+  homepage = "https://github.com/input-output-hk/cardano-report-server";
+  description = "Reporting server for CSL";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/cardano-sl-explorer.nix
+++ b/pkgs/cardano-sl-explorer.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, aeson, base, base16-bytestring, bytestring
+, cardano-sl, cardano-sl-core, cardano-sl-db, cardano-sl-infra
+, cpphs, exceptions, fetchgit, formatting, lens, log-warper
+, monad-loops, mtl, node-sketch, optparse-simple, purescript-bridge
+, serokell-util, servant, servant-server, stdenv, stm, text-format
+, time, transformers, universum, unordered-containers, wai
+}:
+mkDerivation {
+  pname = "cardano-sl-explorer";
+  version = "0.0.1.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/cardano-sl-explorer.git";
+    sha256 = "1faj966kws8mh57c7sz6q3ljsmn3yi411913pxrh1kwkg1lq828n";
+    rev = "349cf68b7453430f649880eb4dabd2ed0b55694f";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base base16-bytestring bytestring cardano-sl cardano-sl-core
+    cardano-sl-db cardano-sl-infra exceptions formatting lens
+    log-warper monad-loops mtl node-sketch servant servant-server stm
+    text-format time transformers universum unordered-containers wai
+  ];
+  libraryToolDepends = [ cpphs ];
+  executableHaskellDepends = [
+    base cardano-sl cardano-sl-core cardano-sl-infra lens log-warper
+    node-sketch optparse-simple purescript-bridge serokell-util
+    universum
+  ];
+  executableToolDepends = [ cpphs ];
+  doCheck = false;
+  description = "Cardano SL main implementation";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/cardano-sl.nix
+++ b/pkgs/cardano-sl.nix
@@ -1,0 +1,82 @@
+{ mkDerivation, acid-state, aeson, ansi-terminal, array, async
+, attoparsec, base, base58-bytestring, base64-bytestring, binary
+, binary-conduit, binary-orphans, bytestring, cardano-crypto
+, cardano-report-server, cardano-sl-core, cardano-sl-db
+, cardano-sl-infra, cardano-sl-lrc, cardano-sl-update, cereal
+, concurrent-extra, conduit, containers, cpphs, cryptonite
+, cryptonite-openssl, data-default, deepseq, derive
+, deriving-compat, digest, directory, dlist, ed25519, exceptions
+, fetchgit, file-embed, filelock, filepath, focus, foldl
+, formatting, gitrev, hashable, hspec, http-client, http-client-tls
+, http-conduit, http-types, IfElse, kademlia, lens, lifted-async
+, list-t, log-warper, lrucache, memory, mmorph, monad-control
+, monad-loops, mono-traversable, mtl, neat-interpolation
+, network-info, network-transport, network-transport-tcp
+, node-sketch, optparse-applicative, optparse-simple, parsec
+, plutus-prototype, process, purescript-bridge, pvss, QuickCheck
+, quickcheck-instances, random, random-shuffle, reflection
+, regex-tdfa, regex-tdfa-text, resourcet, rocksdb, safecopy
+, serokell-util, servant, servant-docs, servant-server, stdenv, stm
+, stm-containers, system-filepath, tagged, tar, template-haskell
+, temporary, text, text-format, th-lift-instances, time, time-units
+, transformers, transformers-base, turtle, universum, unix
+, unordered-containers, vector, wai, wai-extra, wai-websockets
+, warp, websockets, wreq, yaml
+}:
+mkDerivation {
+  pname = "cardano-sl";
+  version = "0.3.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/cardano-sl.git";
+    sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
+    rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    acid-state aeson ansi-terminal async base base58-bytestring
+    base64-bytestring binary binary-conduit binary-orphans bytestring
+    cardano-crypto cardano-report-server cardano-sl-core cardano-sl-db
+    cardano-sl-infra cardano-sl-lrc cardano-sl-update cereal
+    concurrent-extra conduit containers cryptonite cryptonite-openssl
+    data-default deepseq derive deriving-compat digest directory dlist
+    ed25519 exceptions file-embed filelock filepath focus formatting
+    gitrev hashable http-client http-client-tls http-conduit http-types
+    IfElse kademlia lens lifted-async list-t log-warper lrucache memory
+    mmorph monad-control monad-loops mono-traversable mtl
+    neat-interpolation network-info network-transport
+    network-transport-tcp node-sketch optparse-applicative
+    optparse-simple parsec plutus-prototype pvss QuickCheck
+    quickcheck-instances random reflection resourcet rocksdb safecopy
+    serokell-util servant servant-docs servant-server stm
+    stm-containers tagged template-haskell temporary text text-format
+    th-lift-instances time time-units transformers transformers-base
+    turtle universum unordered-containers vector wai wai-extra
+    wai-websockets warp websockets wreq yaml
+  ];
+  libraryToolDepends = [ cpphs ];
+  executableHaskellDepends = [
+    aeson array async attoparsec base base58-bytestring binary
+    bytestring cardano-report-server cardano-sl-core cardano-sl-infra
+    cardano-sl-lrc cardano-sl-update containers cryptonite data-default
+    directory ed25519 filepath foldl formatting kademlia lens
+    lifted-async log-warper mtl network-transport node-sketch
+    optparse-applicative optparse-simple parsec process
+    purescript-bridge QuickCheck random random-shuffle serokell-util
+    stm system-filepath tar text time time-units transformers turtle
+    universum unix unordered-containers vector wreq
+  ];
+  executableToolDepends = [ cpphs ];
+  testHaskellDepends = [
+    base binary bytestring cardano-sl-core cardano-sl-infra cereal
+    containers cryptonite data-default derive formatting hspec kademlia
+    lens log-warper memory mtl node-sketch pvss QuickCheck
+    quickcheck-instances random reflection regex-tdfa regex-tdfa-text
+    safecopy serokell-util time-units universum unordered-containers
+    vector
+  ];
+  testToolDepends = [ cpphs ];
+  doCheck = false;
+  description = "Cardano SL main implementation";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/cryptonite.nix
+++ b/pkgs/cryptonite.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, deepseq, fetchgit, ghc-prim
+, integer-gmp, memory, stdenv, tasty, tasty-hunit, tasty-kat
+, tasty-quickcheck
+}:
+mkDerivation {
+  pname = "cryptonite";
+  version = "0.22";
+  src = fetchgit {
+    url = "https://github.com/haskell-crypto/cryptonite.git";
+    sha256 = "14b64f45fgxq6kdq44ibsw23bzhkfy3arpd0ws468wd7vihdah4v";
+    rev = "6440a7ebab7d85612e47099017bee0da6339af05";
+  };
+  libraryHaskellDepends = [
+    base bytestring deepseq ghc-prim integer-gmp memory
+  ];
+  testHaskellDepends = [
+    base bytestring memory tasty tasty-hunit tasty-kat tasty-quickcheck
+  ];
+  doCheck = false;
+  homepage = "https://github.com/haskell-crypto/cryptonite";
+  description = "Cryptography Primitives sink";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/derive.nix
+++ b/pkgs/derive.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, base, bytestring, containers, directory, fetchgit
+, filepath, haskell-src-exts, pretty, process, stdenv, syb
+, template-haskell, transformers, uniplate
+}:
+mkDerivation {
+  pname = "derive";
+  version = "2.6.2";
+  src = fetchgit {
+    url = "https://github.com/ndmitchell/derive.git";
+    sha256 = "147pcqgm7p0rs08sdfrka6xdw7h0c8c3dwlfi35scj3yxamcda2s";
+    rev = "9b564c23543d92757168581beb832f4dc0db223b";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring containers directory filepath haskell-src-exts
+    pretty process syb template-haskell transformers uniplate
+  ];
+  executableHaskellDepends = [ base ];
+  doCheck = false;
+  homepage = "https://github.com/ndmitchell/derive#readme";
+  description = "A program and library to derive instances for data types";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/ed25519.nix
+++ b/pkgs/ed25519.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, bytestring, directory, doctest, fetchgit
+, filemanip, filepath, ghc-prim, hlint, QuickCheck, stdenv
+}:
+mkDerivation {
+  pname = "ed25519";
+  version = "0.0.5.0";
+  src = fetchgit {
+    url = "https://github.com/thoughtpolice/hs-ed25519.git";
+    sha256 = "0fah4vkmqdkjsdh3s3x27yfaif2fbdg6049xvp54b5mh50yvxkfq";
+    rev = "da4247b5b3420120e20451e6a252e2a2ca15b43c";
+  };
+  libraryHaskellDepends = [ base bytestring ghc-prim ];
+  testHaskellDepends = [
+    base bytestring directory doctest filemanip filepath hlint
+    QuickCheck
+  ];
+  homepage = "https://thoughtpolice.github.com/hs-ed25519";
+  description = "Ed25519 cryptographic signatures";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -j 4 -i bash -p pkgs.cabal2nix
+#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/464c79ea9f929d1237dbc2df878eedad91767a72.tar.gz
+
+set -xe
+
+cabal2nix https://github.com/serokell/universum --no-check --revision 9edb5d374ec1fb6bb873dacc22a013f1eacd9c67 > universum.nix 
+cabal2nix https://github.com/serokell/serokell-util.git --revision af79ca0c42b8fd23c499096f91f649edfb0862f1 > serokell-util.nix
+cabal2nix https://github.com/serokell/acid-state.git --revision 95fce1dbada62020a0b2d6aa2dd7e88eadd7214b > acid-state.nix
+cabal2nix https://github.com/serokell/log-warper.git --revision b3b2d4d5afa2c22f3aff10b4cceab3914c6bc0e5 > log-warper.nix
+cabal2nix https://github.com/serokell/kademlia.git --no-check --revision bf65ac0cd50d2ccd7ef6507f0d71786c4bd10ae1 > kademlia.nix
+cabal2nix https://github.com/serokell/rocksdb-haskell.git --revision 4dfd8d61263d78a91168e86e8005eb9b7069389e > rocksdb-haskell.nix
+cabal2nix https://github.com/serokell/time-warp-nt.git --no-check --revision 2943e7814b9f78b9ef68c9bdc96820ed32a0fdf3 > time-warp-nt.nix
+
+cabal2nix https://github.com/input-output-hk/cardano-sl.git --no-check --revision c10bcd8f19d538c58251e33a994e3246aeda891c > cardano-sl.nix
+cabal2nix https://github.com/input-output-hk/cardano-report-server.git --revision 424e4ecacdf038a01542025dd1296bd272ce770d > cardano-report-server.nix
+cabal2nix https://github.com/input-output-hk/plutus-prototype.git --revision e2e2711e6978002279b4d7c49cab1aff47a2fd43 > plutus-prototype.nix
+
+cabal2nix https://github.com/thoughtpolice/hs-ed25519.git --revision da4247b5b3420120e20451e6a252e2a2ca15b43c > ed25519.nix
+cabal2nix https://github.com/avieth/network-transport.git --no-check --revision f2321a103f53f51d36c99383132e3ffa3ef1c401 > network-transport.nix
+cabal2nix https://github.com/avieth/network-transport-tcp.git --no-check --revision 1739cc6d5c73257201e5551088f4ba56d5ede15c > network-transport-tcp.nix
+cabal2nix https://github.com/ndmitchell/derive.git --no-check --revision 9b564c23543d92757168581beb832f4dc0db223b > derive.nix
+cabal2nix https://github.com/input-output-hk/cardano-crypto --no-check --revision 838b064d8a59286142aa2fe14434fe7601896ddb > cardano-crypto.nix
+cabal2nix https://github.com/haskell-crypto/cryptonite.git --no-check --revision 6440a7ebab7d85612e47099017bee0da6339af05 > cryptonite.nix
+cabal2nix https://github.com/input-output-hk/cardano-sl-explorer.git --no-check --revision 349cf68b7453430f649880eb4dabd2ed0b55694f > cardano-sl-explorer.nix

--- a/pkgs/kademlia.nix
+++ b/pkgs/kademlia.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, base, binary, bytestring, containers, cryptonite
+, data-default, errors, extra, fetchgit, HUnit, memory, MonadRandom
+, mtl, network, QuickCheck, random, random-shuffle, stdenv, stm
+, tasty, tasty-hunit, tasty-quickcheck, time, transformers
+, transformers-compat
+}:
+mkDerivation {
+  pname = "kademlia";
+  version = "1.1.0.1";
+  src = fetchgit {
+    url = "https://github.com/serokell/kademlia.git";
+    sha256 = "0sdb6w33vyx86pbp9s5s8c3lwsahcds2vzhpfpn7p9srp82mb82i";
+    rev = "bf65ac0cd50d2ccd7ef6507f0d71786c4bd10ae1";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base binary bytestring containers cryptonite data-default errors
+    extra memory MonadRandom mtl network random random-shuffle stm time
+    transformers transformers-compat
+  ];
+  executableHaskellDepends = [
+    base binary bytestring containers data-default extra MonadRandom
+    mtl network random random-shuffle transformers transformers-compat
+  ];
+  testHaskellDepends = [
+    base binary bytestring containers data-default errors extra HUnit
+    MonadRandom mtl network QuickCheck random random-shuffle stm tasty
+    tasty-hunit tasty-quickcheck time transformers transformers-compat
+  ];
+  doCheck = false;
+  homepage = "https://github.com/serokell/kademlia";
+  description = "An implementation of the Kademlia DHT Protocol";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/log-warper.nix
+++ b/pkgs/log-warper.nix
@@ -1,0 +1,33 @@
+{ mkDerivation, aeson, ansi-terminal, async, base, bytestring
+, containers, data-default, directory, dlist, errors, exceptions
+, extra, fetchgit, filepath, formatting, hashable, hspec, HUnit
+, lens, monad-control, monad-loops, mtl, network, QuickCheck
+, safecopy, stdenv, text, text-format, time, transformers
+, transformers-base, universum, unix, unordered-containers, yaml
+}:
+mkDerivation {
+  pname = "log-warper";
+  version = "1.0.3";
+  src = fetchgit {
+    url = "https://github.com/serokell/log-warper.git";
+    sha256 = "0zwrjipjbjrqlgwdyn8ad0m28bndgz1dr2z01k4464c1whcy46m1";
+    rev = "b3b2d4d5afa2c22f3aff10b4cceab3914c6bc0e5";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-terminal base bytestring containers directory dlist
+    errors exceptions extra filepath formatting hashable lens
+    monad-control monad-loops mtl network safecopy text text-format
+    time transformers transformers-base universum unix
+    unordered-containers yaml
+  ];
+  executableHaskellDepends = [ base exceptions text ];
+  testHaskellDepends = [
+    async base data-default directory filepath hspec HUnit lens
+    QuickCheck universum unordered-containers
+  ];
+  homepage = "https://github.com/serokell/log-warper";
+  description = "Flexible, configurable, monadic and pretty logging";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/network-transport-tcp.nix
+++ b/pkgs/network-transport-tcp.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, containers, data-accessor
+, fetchgit, network, network-transport, network-transport-tests
+, stdenv
+}:
+mkDerivation {
+  pname = "network-transport-tcp";
+  version = "0.5.1";
+  src = fetchgit {
+    url = "https://github.com/avieth/network-transport-tcp.git";
+    sha256 = "1lznyp62w4h5387p70i4hm29v52bi2cackxl4ig2adfi8dg83i88";
+    rev = "1739cc6d5c73257201e5551088f4ba56d5ede15c";
+  };
+  libraryHaskellDepends = [
+    base bytestring containers data-accessor network network-transport
+  ];
+  testHaskellDepends = [
+    base network network-transport network-transport-tests
+  ];
+  doCheck = false;
+  homepage = "http://haskell-distributed.github.com";
+  description = "TCP instantiation of Network.Transport";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/network-transport.nix
+++ b/pkgs/network-transport.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, binary, bytestring, deepseq, fetchgit
+, hashable, stdenv, transformers
+}:
+mkDerivation {
+  pname = "network-transport";
+  version = "0.5.1";
+  src = fetchgit {
+    url = "https://github.com/avieth/network-transport.git";
+    sha256 = "0gd1c36khb0mdp0w9b8xrmcr1pdnki2l9m2rck8y5lmn5xjf2bhr";
+    rev = "f2321a103f53f51d36c99383132e3ffa3ef1c401";
+  };
+  libraryHaskellDepends = [
+    base binary bytestring deepseq hashable transformers
+  ];
+  doCheck = false;
+  homepage = "http://haskell-distributed.github.com";
+  description = "Network abstraction layer";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/plutus-prototype.nix
+++ b/pkgs/plutus-prototype.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, bifunctors, binary, bytestring
+, cardano-crypto, cryptonite, fetchgit, filepath, lens, memory, mtl
+, parsec, stdenv, transformers
+}:
+mkDerivation {
+  pname = "plutus-prototype";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/plutus-prototype.git";
+    sha256 = "0h2zq1kcss3f43yqhbz8bjpyxfqlf1wkkdwr91vdkcbjmbgkm8hb";
+    rev = "e2e2711e6978002279b4d7c49cab1aff47a2fd43";
+  };
+  libraryHaskellDepends = [
+    base bifunctors binary bytestring cardano-crypto cryptonite
+    filepath lens memory mtl parsec transformers
+  ];
+  homepage = "iohk.io";
+  description = "Prototype of the Plutus language";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/rocksdb-haskell.nix
+++ b/pkgs/rocksdb-haskell.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, base, binary, bytestring, data-default, fetchgit
+, filepath, hspec, hspec-expectations, process, QuickCheck
+, resourcet, rocksdb, stdenv, temporary, transformers
+}:
+mkDerivation {
+  pname = "rocksdb";
+  version = "0.1.0.1";
+  src = fetchgit {
+    url = "https://github.com/serokell/rocksdb-haskell.git";
+    sha256 = "05dwx4wgiqin3ryyjf9z49vxnqs7qzyg296gbbhx3ikg3vxqb3bg";
+    rev = "4dfd8d61263d78a91168e86e8005eb9b7069389e";
+  };
+  libraryHaskellDepends = [
+    base binary bytestring data-default filepath resourcet transformers
+  ];
+  librarySystemDepends = [ rocksdb ];
+  testHaskellDepends = [
+    base bytestring data-default hspec hspec-expectations process
+    QuickCheck resourcet temporary transformers
+  ];
+  homepage = "http://github.com/serokell/rocksdb-haskell";
+  description = "Haskell bindings to RocksDB";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/pkgs/serokell-util.nix
+++ b/pkgs/serokell-util.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, acid-state, aeson, aeson-extra, ansi-terminal, base
+, base16-bytestring, base64-bytestring, binary, binary-orphans
+, bytestring, cereal, cereal-vector, clock, containers
+, data-msgpack, deepseq, directory, either, exceptions, extra
+, fetchgit, filepath, formatting, hashable, hspec, lens, log-warper
+, monad-control, mtl, optparse-applicative, parsec, QuickCheck
+, quickcheck-instances, safecopy, scientific, semigroups, stdenv
+, stm, template-haskell, text, text-format, time-units
+, transformers, universum, unordered-containers, vector, yaml
+}:
+mkDerivation {
+  pname = "serokell-util";
+  version = "0.1.4.0";
+  src = fetchgit {
+    url = "https://github.com/serokell/serokell-util.git";
+    sha256 = "1jlrx2cnlxkglgqkkggsfpjpppvnqn4rcj73jj534dfsd1hh9vv8";
+    rev = "af79ca0c42b8fd23c499096f91f649edfb0862f1";
+  };
+  libraryHaskellDepends = [
+    acid-state aeson aeson-extra ansi-terminal base base16-bytestring
+    base64-bytestring binary binary-orphans bytestring cereal
+    cereal-vector clock containers data-msgpack deepseq directory
+    either exceptions extra filepath formatting hashable lens
+    log-warper monad-control mtl optparse-applicative parsec QuickCheck
+    quickcheck-instances safecopy scientific semigroups stm
+    template-haskell text text-format time-units transformers universum
+    unordered-containers vector yaml
+  ];
+  testHaskellDepends = [
+    aeson base binary bytestring cereal data-msgpack hspec QuickCheck
+    quickcheck-instances safecopy scientific text text-format
+    unordered-containers vector
+  ];
+  homepage = "https://github.com/serokell/serokell-util";
+  description = "General-purpose functions by Serokell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/time-warp-nt.nix
+++ b/pkgs/time-warp-nt.nix
@@ -1,0 +1,41 @@
+{ mkDerivation, async, attoparsec, base, binary, bytestring
+, containers, criterion, data-default, deepseq, ekg, ekg-core
+, exceptions, fetchgit, formatting, hashable, hspec, kademlia, lens
+, log-warper, mmorph, monad-control, mtl, mwc-random, network
+, network-transport, network-transport-inmemory
+, network-transport-tcp, QuickCheck, quickcheck-instances, random
+, semigroups, serokell-util, statistics, stdenv, stm, text
+, text-format, time, time-units, transformers, universum
+, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "node-sketch";
+  version = "0.1.1.0";
+  src = fetchgit {
+    url = "https://github.com/serokell/time-warp-nt.git";
+    sha256 = "0xl4ydbnl187ghpyvgbyi7lf9hw7xhy638ygpzr4d90nav8xmf1q";
+    rev = "2943e7814b9f78b9ef68c9bdc96820ed32a0fdf3";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    async attoparsec base binary bytestring containers data-default
+    deepseq ekg ekg-core exceptions formatting hashable kademlia lens
+    log-warper mmorph monad-control mtl mwc-random network
+    network-transport network-transport-tcp random semigroups
+    serokell-util statistics stm text text-format time time-units
+    transformers universum unordered-containers vector
+  ];
+  executableHaskellDepends = [
+    async base binary bytestring containers criterion mwc-random
+    network-transport network-transport-tcp random statistics stm time
+    time-units vector
+  ];
+  testHaskellDepends = [
+    base binary bytestring containers hspec lens mtl network-transport
+    network-transport-inmemory network-transport-tcp QuickCheck
+    quickcheck-instances random serokell-util stm time-units
+  ];
+  doCheck = false;
+  license = stdenv.lib.licenses.mit;
+}

--- a/pkgs/universum.nix
+++ b/pkgs/universum.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, containers, deepseq, exceptions
+, fetchgit, ghc-prim, hashable, microlens, microlens-mtl, mtl, safe
+, stdenv, stm, text, text-format, transformers, type-operators
+, unordered-containers, utf8-string, vector
+}:
+mkDerivation {
+  pname = "universum";
+  version = "0.3";
+  src = fetchgit {
+    url = "https://github.com/serokell/universum";
+    sha256 = "1cy1mkl2n9kjmya0225nc2bichb60q4y8n3wym7m79qcvsh6rxa2";
+    rev = "9edb5d374ec1fb6bb873dacc22a013f1eacd9c67";
+  };
+  libraryHaskellDepends = [
+    base bytestring containers deepseq exceptions ghc-prim hashable
+    microlens microlens-mtl mtl safe stm text text-format transformers
+    type-operators unordered-containers utf8-string vector
+  ];
+  doCheck = false;
+  homepage = "https://github.com/serokell/universum";
+  description = "Custom prelude used in Serokell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/srk-nixpkgs.nix
+++ b/srk-nixpkgs.nix
@@ -1,251 +1,54 @@
 { pkgs ? (import <nixpkgs> {})
 , compiler ? pkgs.haskell.packages.ghc802
-, genesisN ? 3
-, slotDuration ? 20
-, networkDiameter ? 6
-, mpcRelayInterval ? 16 } :
+}:
 
 with (import <nixpkgs/pkgs/development/haskell-modules/lib.nix> { inherit pkgs;});
 
 let
-  overrideAttrs = package: newAttrs:
-    package.override (args: args // {
-      mkDerivation = expr: args.mkDerivation (expr // newAttrs);
-    });
-
-  # Autogenerate default.nix from cabal file in src
-  haskellPackageGen = { doHaddock ? false, doFilter ? false, doCheck ? true, profiling ? false }: src:
-     let filteredSrc = builtins.filterSource (n: t: t != "unknown") src;
-         package = pkgs.runCommand "default.nix" {} ''
-           ${compiler.cabal2nix}/bin/cabal2nix \
-             ${if doFilter then filteredSrc else src} \
-             ${if doHaddock
-                 then ""
-                 else "--no-haddock"} \
-             ${if doCheck
-                 then ""
-                 else "--no-check"} \
-             ${if profiling
-                 then "--enable-profiling"
-                 else ""} \
-             > $out
-         '';
-     in import package;
+  prodMode = drv: overrideCabal drv (drv: {
+    configureFlags = [ "-f-asserts" "-f-dev-mode"];
+  });
 in rec {
-  universum = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "universum";
-        rev = "9edb5d374ec1fb6bb873dacc22a013f1eacd9c67";
-        sha256 = "1cy1mkl2n9kjmya0225nc2bichb60q4y8n3wym7m79qcvsh6rxa2";
-      })
-  ) { };
-  serokell-util = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "serokell-util";
-        rev = "af79ca0c42b8fd23c499096f91f649edfb0862f1";
-        sha256 = "1jlrx2cnlxkglgqkkggsfpjpppvnqn4rcj73jj534dfsd1hh9vv8";
-      })
-  ) { };
-  acid-state = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "acid-state";
-        rev = "95fce1dbada62020a0b2d6aa2dd7e88eadd7214b";
-        sha256 = "109liqzk66cxkarw8r8jxh27n6qzdcha2xlhsj56xzyqc2aqjz15";
-      })
-  ) { };
-  log-warper = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "log-warper";
-        rev = "b3b2d4d5afa2c22f3aff10b4cceab3914c6bc0e5";
-        sha256 = "0zwrjipjbjrqlgwdyn8ad0m28bndgz1dr2z01k4464c1whcy46m1";
-      })
-  ) { };
-  network-transport-tcp = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "avieth";
-        repo = "network-transport-tcp";
-        rev = "1739cc6d5c73257201e5551088f4ba56d5ede15c";
-        sha256 = "1lznyp62w4h5387p70i4hm29v52bi2cackxl4ig2adfi8dg83i88";
-      })
-  ) { };
-  network-transport = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "avieth";
-        repo = "network-transport";
-        rev = "f2321a103f53f51d36c99383132e3ffa3ef1c401";
-        sha256 = "0gd1c36khb0mdp0w9b8xrmcr1pdnki2l9m2rck8y5lmn5xjf2bhr";
-      })
-  ) { };
-  plutus-prototype = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "plutus-prototype";
-        rev = "e2e2711e6978002279b4d7c49cab1aff47a2fd43";
-        sha256 = "0h2zq1kcss3f43yqhbz8bjpyxfqlf1wkkdwr91vdkcbjmbgkm8hb";
-      })
-  ) { };
-  ed25519 = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "domenkozar";
-        repo = "hs-ed25519";
-        rev = "57adb970e198a9b377769ab46e776ec29f19cff6";
-        sha256 = "1xkd683d3p84a4as38i4s99mz7pnhs7r4s7jwj91shri850n112j";
-      })
-  ) { };
-  rocksdb-haskell = hspkgs.callPackage (
-    haskellPackageGen {} (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "rocksdb-haskell";
-        rev = "4dfd8d61263d78a91168e86e8005eb9b7069389e";
-        sha256 = "05dwx4wgiqin3ryyjf9z49vxnqs7qzyg296gbbhx3ikg3vxqb3bg";
-        # rev = "cbe733d9bbdc61b07d9a6fd0bc7964ac1e78f6a5";
-        # sha256 = "0hi5fda4h8q1jrdr6k0knxhzs08lhwc5a7achj0ys75snh7w5151";
-      })
-  ) { };
-  kademlia = hspkgs.callPackage (
-    haskellPackageGen { doCheck = false; } (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "kademlia";
-        rev = "bf65ac0cd50d2ccd7ef6507f0d71786c4bd10ae1";
-        sha256 = "0sdb6w33vyx86pbp9s5s8c3lwsahcds2vzhpfpn7p9srp82mb82i";
-      })
-  ) { };
-  node-sketch = hspkgs.callPackage (
-    haskellPackageGen { } (pkgs.fetchFromGitHub {
-        owner = "serokell";
-        repo = "time-warp-nt";
-        rev = "2943e7814b9f78b9ef68c9bdc96820ed32a0fdf3";
-        sha256 = "0xl4ydbnl187ghpyvgbyi7lf9hw7xhy638ygpzr4d90nav8xmf1q";
-      })
-  ) { };
-  cardano-report-server = hspkgs.callPackage (
-    haskellPackageGen { } (pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-report-server";
-        rev = "424e4ecacdf038a01542025dd1296bd272ce770d";
-        sha256 = "11wq4wjp45mn45x3109xi64p824mlimjkd4dk6r7gnmd0l9v77mh";
-      })
-  ) { };
-
-  cardano-sl-core = hspkgs.callPackage (
-    haskellPackageGen { } ("${pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-sl";
-        rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
-        sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
-      }}/core")
-  ) { };
-
-    cardano-sl-db = hspkgs.callPackage (
-    haskellPackageGen { } ("${pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-sl";
-        rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
-        sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
-      }}/db")
-  ) { rocksdb = rocksdb-haskell; };
-
-    cardano-sl-infra = hspkgs.callPackage (
-    haskellPackageGen { } ("${pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-sl";
-        rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
-        sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
-      }}/infra")
-  ) { };
-
-    cardano-sl-update = hspkgs.callPackage (
-    haskellPackageGen { } ("${pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-sl";
-        rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
-        sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
-      }}/update")
-  ) { };
-
-    cardano-sl-lrc = hspkgs.callPackage (
-    haskellPackageGen { } ("${pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-sl";
-        rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
-        sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
-      }}/lrc")
-  ) { };
-
-    cardano-sl = hspkgs.callPackage (
-    haskellPackageGen { } (pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-sl";
-        rev = "c10bcd8f19d538c58251e33a994e3246aeda891c";
-        sha256 = "1r4fam0r55ivb9wrsfyz8ja5kfaz5m4pzg31ncjspq9rrl2la6id";
-      })
-  ) { rocksdb = rocksdb-haskell; };
-
-      cardano-crypto = hspkgs.callPackage (
-    haskellPackageGen { } (pkgs.fetchFromGitHub {
-        owner = "input-output-hk";
-        repo = "cardano-crypto";
-        rev = "838b064d8a59286142aa2fe14434fe7601896ddb";
-        sha256 = "02gjaj7889y30g2qfdh96ywrsdpmgfgyqyajw49zaklwjvkh87sv";
-      })
-  ) { };
-
-    cryptonite = hspkgs.callPackage (
-    haskellPackageGen { } (pkgs.fetchFromGitHub {
-        owner = "haskell-crypto";
-        repo = "cryptonite";
-        rev = "6440a7ebab7d85612e47099017bee0da6339af05";
-        sha256 = "14b64f45fgxq6kdq44ibsw23bzhkfy3arpd0ws468wd7vihdah4v";
-      })
-  ) { };
-
-
   hspkgs = compiler.override {
     overrides = self: super: {
-      inherit universum acid-state kademlia plutus-prototype node-sketch network-transport-tcp ed25519 log-warper cardano-report-server network-transport serokell-util cardano-sl-db cardano-crypto cardano-sl-infra cardano-sl-update cardano-sl-lrc cryptonite;
+      # To generate these go to ./pkgs and run ./generate.sh
+      universum = super.callPackage ./pkgs/universum.nix { };
+      serokell-util = super.callPackage ./pkgs/serokell-util.nix { };
+      acid-state = super.callPackage ./pkgs/acid-state.nix { };
+      log-warper = super.callPackage ./pkgs/log-warper.nix { };
+      ed25519 = super.callPackage ./pkgs/ed25519.nix { };
+      rocksdb = super.callPackage ./pkgs/rocksdb-haskell.nix { rocksdb = pkgs.rocksdb; };
+      kademlia = super.callPackage ./pkgs/kademlia.nix { };
+      node-sketch = super.callPackage ./pkgs/time-warp-nt.nix { };
+      cardano-report-server = super.callPackage ./pkgs/cardano-report-server.nix { };
+      cardano-crypto = super.callPackage ./pkgs/cardano-crypto.nix { };
+      plutus-prototype = super.callPackage ./pkgs/plutus-prototype.nix { };
+      network-transport = super.callPackage ./pkgs/network-transport.nix { };
+      network-transport-tcp = super.callPackage ./pkgs/network-transport-tcp.nix { };
+      derive = super.callPackage ./pkgs/derive.nix { };
+      cryptonite = super.callPackage ./pkgs/cryptonite.nix { };
 
-      QuickCheck = super.QuickCheck_2_9_2;
-      optparse-applicative = super.optparse-applicative_0_13_0_0;
-      criterion = super.criterion_1_1_4_0;
-      #code-page = super.code-page_0_1_1;
+      # TODO: https://github.com/NixOS/cabal2nix/issues/261
+      cardano-sl-core = prodMode (super.callCabal2nix "cardano-sl-core" "${self.cardano-sl.src}/core" {});
+      cardano-sl-db = super.callCabal2nix "cardano-sl-db" "${self.cardano-sl.src}/db" {};
+      cardano-sl-infra = prodMode (super.callCabal2nix "cardano-sl-infra" "${self.cardano-sl.src}/infra" {});
+      cardano-sl-lrc = super.callCabal2nix "cardano-sl-lrc" "${self.cardano-sl.src}/lrc" {};
+      cardano-sl-update = super.callCabal2nix "cardano-sl-update" "${self.cardano-sl.src}/update" {};
+      cardano-sl-explorer = prodMode (super.callPackage ./pkgs/cardano-sl-explorer.nix { });
 
-      turtle = doJailbreak super.turtle_1_3_0;
-
-      cardano-sl-core = overrideCabal cardano-sl-core (drv: {
-        configureFlags = ["-f-dev-mode"];
-      });
-
-
-      cardano-sl = overrideCabal cardano-sl (drv: {
-        # Build statically to reduce closure size
-        enableSharedLibraries = false;
-        enableSharedExecutables = false;
-        isLibrary = false;
+      cardano-sl = overrideCabal (super.callPackage ./pkgs/cardano-sl.nix { }) (drv: {
         patchPhase = ''
          export CSL_SYSTEM_TAG=linux64
         '';
         # production full nodes shouldn't use wallet as it means different constants
-        configureFlags = [ "-f-asserts" "-f-with-wallet" "-f-with-web" "-f-dev-mode"];
-        # speed up production build
-        doHaddock = false;
-        doCheck = false;
-        postFixup = ''
-          echo "Removing $out/lib to spare HDD space for deployments"
-          rm -rf $out/lib
-        '';
+        configureFlags = [ "-f-asserts" "-f-dev-mode" "-fwith-explorer"];
       });
+      cardano-sl-static = justStaticExecutables self.cardano-sl; 
+      cardano-sl-explorer-static = justStaticExecutables self.cardano-sl-explorer; 
 
-      mkDerivation = args: super.mkDerivation (args // {
-        #enableLibraryProfiling = false;
-
-        # too many test dep mismatches with new quickcheck
-        doCheck = false;
-      });
+      #mkDerivation = args: super.mkDerivation (args // {
+      #enableLibraryProfiling = false;
+      #});
     };
   };
-
 }


### PR DESCRIPTION
Previously we were using `haskellPackageGen`, which generates packages
from their source, but this is using import-from-derivation
feature in Nix, meaning that evaluation and realization mix and match.

It was especially problematic for Hydra as it was building packages during evaluation and it timed out after 1h.

Now we have a `pkgs/generate.sh` file that also doesn't need to specify
sha256 so bumping packages is easier.

Soon that should be all automated using `stack2nix`.