### PR TITLE
[DEVOPS-2] tarsnap: backup deployer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ txgen.json
 smart-gen-*
 static/id_buildfarm
 *prof
+static/*.secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
 install:
   - nix-env -iA nixopsUnstable -f '<nixpkgs>'
   - touch datadog.secret
+  - echo "secret" > static/tarsnap-cardano-deployer.secret
   - mkdir keys
   - touch keys/key{0,1,2,3,4,5,6,7,8,9,10,11,12,13,41}.sk
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: nix
 
 env:
-  NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/3e47e6251930294711d625a8123b7f395dd16b58.tar.gz
+  NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/fe62c993b5dfecb871a54eb6654b09bcd5595fe5.tar.gz
 
 install:
   - nix-env -iA nixopsUnstable -f '<nixpkgs>'

--- a/deployments/infrastructure-target-aws.nix
+++ b/deployments/infrastructure-target-aws.nix
@@ -22,12 +22,16 @@ with (import ./../lib.nix);
       ./../modules/amazon-base.nix
     ];
 
+    deployment.keys.tarsnap = {
+      keyFile = ./../static/tarsnap-cardano-deployer.secret;
+      destDir = "/var/lib/keys";
+    };
+
     deployment.ec2 = {
       # 16G memory needed for 100 nodes evaluation
       instanceType = mkForce "r3.large";
       ebsInitialRootDiskSize = mkForce 50;
       associatePublicIpAddress = true;
-      ami = mkForce "ami-01f7306e";
     };
   };
 }

--- a/deployments/infrastructure.nix
+++ b/deployments/infrastructure.nix
@@ -51,6 +51,22 @@ with (import ./../lib.nix);
       groups.live-production = {};
     };
 
+    services.tarsnap = {
+      enable = true;
+      keyfile = "/var/lib/keys/tarsnap";
+      archives.cardano-deployer = {
+        directories = [
+          "/home/staging/.ec2-keys"
+          "/home/staging/.aws"
+          "/home/staging/.nixops"
+          "/home/live-production/.ec2-keys"
+          "/home/live-production/.aws"
+          "/home/live-production/.nixops"
+          "/etc/"
+        ];
+      };
+    };
+
     networking.firewall.allowedTCPPortRanges = [
       { from = 24962; to = 25062; }
     ];

--- a/lib.nix
+++ b/lib.nix
@@ -42,14 +42,6 @@ in lib // (rec {
 
   cconf = import ./config.nix;
 
-  # Helper function to retrieve a key into a string bypassing nix store
-  getKey = keyFile:
-    let
-      key = toString keyFile;
-    in if builtins.pathExists key
-       then builtins.readFile key
-       else throw (key + " is missing, it's required for the deployment.");
-
   # Function to generate DHT key
   genDhtKey = i: (builtins.fromJSON (builtins.readFile ./static/dht.json))."node${toString i}";
 

--- a/lib.nix
+++ b/lib.nix
@@ -42,6 +42,14 @@ in lib // (rec {
 
   cconf = import ./config.nix;
 
+  # Helper function to retrieve a key into a string bypassing nix store
+  getKey = keyFile:
+    let
+      key = toString keyFile;
+    in if builtins.pathExists key
+       then builtins.readFile key
+       else throw (key + " is missing, it's required for the deployment.");
+
   # Function to generate DHT key
   genDhtKey = i: (builtins.fromJSON (builtins.readFile ./static/dht.json))."node${toString i}";
 

--- a/modules/amazon-base.nix
+++ b/modules/amazon-base.nix
@@ -8,7 +8,6 @@ with (import ./../lib.nix);
  deployment.ec2.region = mkDefault region;
  deployment.ec2.keyPair = mkDefault (resources.ec2KeyPairs.${keypairFor region});
  deployment.ec2.securityGroups = mkDefault ["cardano-deployment"];
- deployment.ec2.ami = (import ./amis.nix).${config.deployment.ec2.region};
- deployment.ec2.accessKeyId = mkDefault "cardano-deployer";
+deployment.ec2.accessKeyId = mkDefault "cardano-deployer";
  deployment.ec2.ebsInitialRootDiskSize = mkDefault 30;
 }

--- a/modules/cardano-node-aws.nix
+++ b/modules/cardano-node-aws.nix
@@ -16,6 +16,7 @@ testIndex: region:
                              (lib.filter (node: node.config.services.cardano-node.enable) nodes))
       );
 
+      deployment.ec2.ami = (import ./amis.nix).${config.deployment.ec2.region};
       deployment.ec2.region = region;
       deployment.ec2.keyPair = resources.ec2KeyPairs.${keypairFor region};
       deployment.keys = optionalAttrs cfg.productionMode {


### PR DESCRIPTION
# Changes

- set ami only for cardano nodes
- configure tarsnap backups for cardano-deployer
- bump nixops to be able to set `destDir` to avoid non-persistent key storage

# TODO

- [x] store secret persistently
- [x] create an issue for snapshots -> DEVOPS-120
- [x] update deployment plan to generate tarsnap key
- [x] depends on https://github.com/NixOS/nixops/pull/664

# Deploy

- [ ] Bump nixpkgs to fe62c993b5dfecb871a54eb6654b09bcd5595fe5
- [ ] create root key
- [ ] backup root key