### PR TITLE
[DEVOPS-3] Setup datadog for prod nodes and hydra/deployer

### DIFF
--- a/deployments/cardano-prod.nix
+++ b/deployments/cardano-prod.nix
@@ -1,0 +1,12 @@
+with (import ./../lib.nix);
+
+let
+  conf = { config, pkgs, resources, ... }: {
+    imports = [
+      ./../modules/datadog.nix
+    ];
+    services.dd-agent.tags = ["prod"];
+  };
+in {
+  report-server = conf;
+} // (genAttrs' (range 0 13) (key: "node${toString key}") (name: conf))

--- a/deployments/infrastructure.nix
+++ b/deployments/infrastructure.nix
@@ -15,7 +15,11 @@ with (import ./../lib.nix);
       ./../modules/hydra-master.nix
       ./../modules/common.nix
       ./../modules/amazon-base.nix
+      ./../modules/datadog.nix
     ];
+
+    # TODO: move into separate -prod.nix
+    services.dd-agent.tags = ["prod"];
 
     networking.firewall.enable = mkForce true;
 
@@ -32,7 +36,11 @@ with (import ./../lib.nix);
     imports = [
       ./../modules/common.nix
       ./../modules/amazon-base.nix
+      ./../modules/datadog.nix
     ];
+
+    # TODO: move into separate -prod.nix
+    services.dd-agent.tags = ["prod"];
 
     users = {
       users.staging = {

--- a/modules/datadog.nix
+++ b/modules/datadog.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, lib, ... }:
+
+with (import ./../lib.nix);
+
+{
+  config = {
+    services.dd-agent = {
+      enable = true;
+      api_key = fileContents ./../datadog.secret;
+      hostname = config.networking.hostName;
+    };
+  };
+}


### PR DESCRIPTION
TODO:

- [x] instructions how to include datadog into production nodes for next deploy
- [x] copy datadog api key to staging
- [x] test node cluster deploy
- [x] decide where is the single source of truth for changes in next deploy

### Notes for future deploys

- bump nixpkgs to 7ad99e9fc8c1977f4d51ba8531386fce7276d300
- add `deployments/cardano-prod.nix` to `deploymentFiles` section of yaml