### PR TITLE
[DEVOPS-86] Explorer staging deployment

### DIFF
--- a/deployments/cardano-explorer-staging.nix
+++ b/deployments/cardano-explorer-staging.nix
@@ -1,0 +1,83 @@
+with (import ./../lib.nix);
+
+let
+  cconf = import ./../config.nix;
+
+  nodeGenericConfig = testIndex: region: keypair: {resources, pkgs, ...}: {
+    imports = [
+      ./../modules/common.nix
+      ./../modules/amazon-base.nix
+    ];
+
+    services.cardano-node = {
+      enable = true;
+      port = cconf.nodePort;
+      testIndex = testIndex;
+      dhtKey = genDhtKey { i = testIndex; };
+      stats = false;
+      jsonLog = true;
+      distribution = true;
+      peersFile = pkgs.fetchurl {
+         url = "https://raw.githubusercontent.com/input-output-hk/daedalus/cardano-sl-0.4/installers/data/ip-dht-mappings";
+         sha256 = "02nlxx28r1fc3ncc1qmzvxv6vlmy1i8rll10alr6fh9qf9nxwzbv";
+       };
+      inherit (cconf) enableP2P genesisN slotDuration networkDiameter mpcRelayInterval totalMoneyAmount bitcoinOverFlat productionMode systemStart richPoorDistr;
+    };
+  } // optionalAttrs (generatingAMI == false) ({
+      deployment.ec2.region = mkForce region;
+      deployment.ec2.keyPair = mkForce (keypair resources.ec2KeyPairs);
+      deployment.ec2.elasticIPv4 = resources.elasticIPs.${"nodeip" + toString testIndex};
+    } // optionalAttrs cconf.productionMode  {
+      #deployment.keys."key${toString (testIndex + 1)}" = {
+      #  text = builtins.readFile (builtins.getEnv("PWD") + "/keys/key${toString (testIndex + 1)}.sk");
+      #  user = "cardano-node";
+      #};
+  });
+
+  cardano-node = {testIndex, region, keypair}: {pkgs, ...}: {
+    imports = [ (nodeGenericConfig testIndex region keypair) ];
+  };
+
+  regionIndex = region: keypair: testIndex: cardano-node { inherit region testIndex keypair; };
+in {
+  network.description = "Cardano SL explorer";
+
+  sl-explorer = { pkgs, config, lib, resources, ... }: {
+    imports = [
+      (nodeGenericConfig 40 "eu-central-1" (pairs: pairs.cardano-test-eu-central))
+    ];
+
+    services.cardano-node = {
+      executable = "${(import ./../default.nix {}).cardano-sl-explorer-static}/bin/cardano-explorer";
+      autoStart = true;
+    };
+
+    networking.firewall.allowedTCPPorts = [
+      80 #nginx
+      8110
+    ];
+
+    services.nginx = {
+      enable = true;
+      virtualHosts = {
+        "cardano-explorer-dev.iohk.io" = {
+          # TLS provided by cloudfront
+          locations = {
+            # TODO: one day we'll build purescript with Nix!
+            # but today, this is built by ./scripts/generate-explorer-frontend.sh
+            "/".root = ./../cardano-sl-explorer/frontend/dist;
+            "/api/".proxyPass = "http://localhost:8100";
+          };
+        };
+      };
+    };
+  };
+
+  resources = {
+    inherit ec2KeyPairs;
+    elasticIPs =
+      {
+        nodeip40 = { inherit region accessKeyId; };
+      };
+  };
+}

--- a/deployments/cardano-explorer-staging.nix
+++ b/deployments/cardano-explorer-staging.nix
@@ -45,32 +45,8 @@ in {
   sl-explorer = { pkgs, config, lib, resources, ... }: {
     imports = [
       (nodeGenericConfig 40 "eu-central-1" (pairs: pairs.cardano-test-eu-central))
+      ./../modules/cardano-explorer.nix
     ];
-
-    services.cardano-node = {
-      executable = "${(import ./../default.nix {}).cardano-sl-explorer-static}/bin/cardano-explorer";
-      autoStart = true;
-    };
-
-    networking.firewall.allowedTCPPorts = [
-      80 #nginx
-      8110
-    ];
-
-    services.nginx = {
-      enable = true;
-      virtualHosts = {
-        "cardano-explorer-dev.iohk.io" = {
-          # TLS provided by cloudfront
-          locations = {
-            # TODO: one day we'll build purescript with Nix!
-            # but today, this is built by ./scripts/generate-explorer-frontend.sh
-            "/".root = ./../cardano-sl-explorer/frontend/dist;
-            "/api/".proxyPass = "http://localhost:8100";
-          };
-        };
-      };
-    };
   };
 
   resources = {

--- a/deployments/cardano.nix
+++ b/deployments/cardano.nix
@@ -80,35 +80,11 @@ in
     deployment.ec2.elasticIPv4 = resources.elasticIPs.report-server-ip;
   };
 
-  sl-explorer = { pkgs, config, lib, resources, ... }: {
+  sl-explorer = { pkgs, ... }: {
     imports = [
       (nodeGenericConfig 40 "eu-central-1" (pairs: pairs.cardano-test-eu-central))
+      ./../modules/cardano-explorer.nix
     ];
-
-    services.cardano-node = {
-      executable = "${(import ./../default.nix {}).cardano-sl-explorer-static}/bin/cardano-explorer";
-      autoStart = true;
-    };
-
-    networking.firewall.allowedTCPPorts = [
-      80 #nginx
-      8110
-    ];
-
-    services.nginx = {
-      enable = true;
-      virtualHosts = {
-        "cardano-explorer-dev.iohk.io" = {
-          # TLS provided by cloudfront
-          locations = {
-            # TODO: one day we'll build purescript with Nix!
-            # but today, this is built by ./scripts/generate-explorer-frontend.sh
-            "/".root = ./../cardano-sl-explorer/frontend/dist;
-            "/api/".proxyPass = "http://localhost:8100";
-          };
-        };
-      };
-    };
   };
 
   resources = {

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -12,13 +12,6 @@ with (import ./../lib.nix);
       autoStart = true;
     };
 
-    # Otherwise nginx serves files with timestamps unixtime+1 from /nix/store
-    extraConfig = ''
-      if_modified_since off;
-      add_header Last-Modified "";
-      etag off;
-    '';
-
     networking.firewall.allowedTCPPorts = [
       80 # nginx
       8110 # websocket
@@ -35,6 +28,12 @@ with (import ./../lib.nix);
             "/".root = ./../cardano-sl-explorer/frontend/dist;
             "/api/".proxyPass = "http://localhost:8100";
           };
+          # Otherwise nginx serves files with timestamps unixtime+1 from /nix/store
+          extraConfig = ''
+            if_modified_since off;
+            add_header Last-Modified "";
+            etag off;
+          '';
         };
       };
     };

--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -1,0 +1,42 @@
+{ config, pkgs, lib, ... }:
+
+with (import ./../lib.nix);
+
+{
+  options = {
+  };
+
+  config = {
+    services.cardano-node = {
+      executable = "${(import ./../default.nix {}).cardano-sl-explorer-static}/bin/cardano-explorer";
+      autoStart = true;
+    };
+
+    # Otherwise nginx serves files with timestamps unixtime+1 from /nix/store
+    extraConfig = ''
+      if_modified_since off;
+      add_header Last-Modified "";
+      etag off;
+    '';
+
+    networking.firewall.allowedTCPPorts = [
+      80 # nginx
+      8110 # websocket
+    ];
+
+    services.nginx = {
+      enable = true;
+      virtualHosts = {
+        "cardano-explorer-dev.iohk.io" = {
+          # TLS provided by cloudfront
+          locations = {
+            # TODO: one day we'll build purescript with Nix!
+            # but today, this is built by ./scripts/generate-explorer-frontend.sh
+            "/".root = ./../cardano-sl-explorer/frontend/dist;
+            "/api/".proxyPass = "http://localhost:8100";
+          };
+        };
+      };
+    };
+  };
+}

--- a/pkgs/cardano-sl-explorer.nix
+++ b/pkgs/cardano-sl-explorer.nix
@@ -14,8 +14,8 @@ mkDerivation {
   version = "1.0.0";
   src = fetchgit {
     url = "https://github.com/input-output-hk/cardano-sl-explorer.git";
-    sha256 = "1b40nldvkaji5k4l389ndl0v96pwvvb0jlcgilqia3appjpv8xdc";
-    rev = "a7f23de9bb8253e61a69d9acc3a1d5ad77680973";
+    sha256 = "0pdbdx4j8qb3kb5pzihk11b81s5yaj4nsds7dmi2f0bszz3jw75a";
+    rev = "e3bb99dc5427d4e386859f4e22da72d3686d5d50";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -18,7 +18,7 @@ cabal2nix https://github.com/avieth/network-transport-tcp.git --no-check --revis
 cabal2nix https://github.com/ndmitchell/derive.git --no-check --revision 9b564c23543d92757168581beb832f4dc0db223b > derive.nix
 cabal2nix https://github.com/input-output-hk/cardano-crypto --no-check --revision 838b064d8a59286142aa2fe14434fe7601896ddb > cardano-crypto.nix
 cabal2nix https://github.com/haskell-crypto/cryptonite.git --no-check --revision 6440a7ebab7d85612e47099017bee0da6339af05 > cryptonite.nix
-cabal2nix https://github.com/input-output-hk/cardano-sl-explorer.git --no-check --revision a7f23de9bb8253e61a69d9acc3a1d5ad77680973 > cardano-sl-explorer.nix
+cabal2nix https://github.com/input-output-hk/cardano-sl-explorer.git --no-check --revision e3bb99dc5427d4e386859f4e22da72d3686d5d50 > cardano-sl-explorer.nix
 
 cabal2nix https://github.com/input-output-hk/cardano-report-server.git --revision 424e4ecacdf038a01542025dd1296bd272ce770d > cardano-report-server.nix
 cabal2nix https://github.com/input-output-hk/plutus-prototype.git --revision e2e2711e6978002279b4d7c49cab1aff47a2fd43 > plutus-prototype.nix


### PR DESCRIPTION
This is not ideal, as it duplicates things. It will be addressed in DEVOPS-37.

https://cardano-explorer-dev.iohk.io/

Instructions: https://input-output-rnd.slack.com/archives/C3NJV7ADQ/p1493300293365767

- [x] share the module between production and staging deploys
- [x] fix last-modified headers
- [x] bump explorer to fix socket-io