### PR TITLE
[DEVOPS-45] Monitor cardano-node process on datadog

### DIFF
--- a/deployments/cardano-prod.nix
+++ b/deployments/cardano-prod.nix
@@ -6,13 +6,24 @@ let
       ./../modules/datadog.nix
       ./../modules/papertrail.nix
     ];
-    services.dd-agent.tags = ["env:production"];
 
     # DEVOPS-64: disable log bursting
     services.journald.rateLimitBurst = 0;
 
     # Initial block is big enough to hold 3 months of transactions
     deployment.ec2.ebsInitialRootDiskSize = mkForce 700;
+
+    services.dd-agent.tags = ["env:production"];
+    services.dd-agent.processConfig = ''
+      init_config:
+
+      instances:
+      - name: cardano-node
+        search_string: ['cardano-node']
+        exact_match: False
+        thresholds:
+          critical: [1, 1]
+    '';
   };
 in {
   report-server = conf;


### PR DESCRIPTION
This requires upstream changes in nixpkgs: https://github.com/NixOS/nixpkgs/pull/25288

A single node using process monitoring is running at `[staging@cardano-deployer:~/devops-45-monitor-cardano-node-process]$ nixops ssh -d devops-41 node0`