### PR TITLE
[DEVOPS-60]  Redirect output of CardanoCSL.hs/generate-ipdht from file to stdout

### DIFF
--- a/CardanoCSL.hs
+++ b/CardanoCSL.hs
@@ -212,7 +212,7 @@ generateIPDHTMappings c = runError $ do
   config@Config{..} <- ExceptT $ getConfig
   dhtfile <- lift $ Prelude.readFile "static/dht.json"
   let peers = genPeers dhtfile nodePort (M.toList nodes)
-  lift $ TIO.writeFile "daedalus/installers/data/ip-dht-mappings" $ T.unlines peers
+  lift $ TIO.putStrLn $ T.unlines peers
   return $ T.unlines peers
 -- Rest
 


### PR DESCRIPTION
This executes on the code modification part of https://issues.serokell.io/issue/DEVOPS-60

@domenkozar, I've been operating under assumption that to this day this tool was used manually, since there are no mentions of `generate-ipdht` neither in `iohk-nixops`, nor in `daedalus` or `cardano-sl`.

One consequence is that there is no integration to update, so this is actually a very very trivial change AIUI.

Please correct me if I'm wrong!