### PR TITLE
[DEVOPS-98] Proxy socket.io through nginx to fix cloudflare

### DIFF
--- a/modules/cardano-explorer.nix
+++ b/modules/cardano-explorer.nix
@@ -14,7 +14,6 @@ with (import ./../lib.nix);
 
     networking.firewall.allowedTCPPorts = [
       80 # nginx
-      8110 # websocket
     ];
 
     services.nginx = {
@@ -31,6 +30,7 @@ with (import ./../lib.nix);
               tryFiles = "$uri /index.html";
             };
             "/api/".proxyPass = "http://localhost:8100";
+            "/socket.io/".proxyPass = "http://localhost:8110";
           };
           # Otherwise nginx serves files with timestamps unixtime+1 from /nix/store
           extraConfig = ''


### PR DESCRIPTION
This needs a counterpart fix in explorer not to set port when ran in production.

I have deployed the change to https://explorer.iohkdev.io/ and it works 