### PR TITLE
[DEVOPS-25] provision node secret key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: nix
 
 env:
-  NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/b9628313300b7c9e4cc88b91b7c98dfe3cfd9fc4.tar.gz
+  NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/3e47e6251930294711d625a8123b7f395dd16b58.tar.gz
 
 install:
-  - nix-env -iA nixpkgs.nixops
+  - nix-env -iA nixopsUnstable -f '<nixpkgs>'
+  - touch datadog.secret
+  - mkdir keys
+  - touch keys/key{0,1,2,3,4,5,6,7,8,9,10,11,12,13,41}.sk
 script:
-  - echo "" > datadog.secret
+  - nixops --version
   # check all scripts compile
   - ./CardanoCSL.hs --help
   - ./TimeWarp.hs --help

--- a/modules/cardano-node-aws.nix
+++ b/modules/cardano-node-aws.nix
@@ -18,9 +18,10 @@ testIndex: region:
 
       deployment.ec2.region = region;
       deployment.ec2.keyPair = resources.ec2KeyPairs.${keypairFor region};
-      #} // lib.optionalAttrs cfg.productionMode  {
-        #deployment.keys."key${toString (testIndex + 1)}" = {
-        #  text = builtins.readFile (builtins.getEnv("PWD") + "/keys/key${toString (testIndex + 1)}.sk");
-        #  user = "cardano-node";
-        #};
+      deployment.keys = optionalAttrs cfg.productionMode {
+        "key${toString (testIndex + 1)}" = {
+          keyFile = ./. + "/../keys/key${toString (testIndex + 1)}.sk";
+          user = "cardano-node";
+        };
+      };
     }

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -8,7 +8,8 @@ with (import ./../lib.nix);
   ];
 
   environment.systemPackages = with pkgs;
-    [ git tmux vim sysstat nixops lsof ncdu tree mosh tig
+    # nixopsUnstable: wait for 1.5.1 release
+    [ git tmux vim sysstat nixopsUnstable lsof ncdu tree mosh tig
       cabal2nix stack iptables graphviz ];
 
   services.openssh.passwordAuthentication = true;


### PR DESCRIPTION
Rebased on top of https://github.com/input-output-hk/iohk-nixops/pull/47

Tested via small node deployment, the key is uploaded and copied to `/var/lib/cardano-node/keyX.sk`

TODO:

- [ ] deploy newer nixops version to deployer box (latest NixOS 17.03)