### PR TITLE
[DEVOPS-46] Restart cardano-node a few times

### DIFF
--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -151,8 +151,11 @@ in {
       serviceConfig = {
         User = "cardano-node";
         Group = "cardano-node";
-#        Restart = "always";
-        StartLimitInterval=0;
+        # Allow a maximum of 5 retries separated by 30 seconds, in total capped by 200s
+        Restart = "always";
+        RestartSec = 30;
+        StartLimitInterval = 200;
+        StartLimitBurst = 5;
         KillSignal = "SIGINT";
         WorkingDirectory = stateDir;
         PrivateTmp = true;


### PR DESCRIPTION
Tested using 1 node and:

```
systemctl start cardano-node
systemctl status cardano-node
kill 1849
systemctl status cardano-node
# node is down
# wait 5s
systemctl status cardano-node
# see that node is back up
```