### PR TITLE
[DEVOPS-58] Automate creating security groups

### DIFF
--- a/deployments/keypairs.nix
+++ b/deployments/keypairs.nix
@@ -1,7 +1,39 @@
 with (import ./../lib.nix);
 
-{
+let
+  regions = [
+    "eu-central-1"
+    "eu-west-1"
+    "eu-west-2"
+    "ap-southeast-1"
+    "ap-southeast-2"
+    "ap-northeast-1"
+    "ap-northeast-2"
+  ];
+  genSG = sgs: mergeAttrs (map sgs regions);
+in {
   resources = {
     inherit ec2KeyPairs;
+    ec2SecurityGroups = genSG (region: {
+      /*"allow-cardano-${region}" = {
+        inherit region accessKeyId;
+        description = "Security group for cardano nodes";
+        rules = [{
+          fromPort = 22;
+          toPort = 22;
+          sourceIp = "0.0.0.0/0";
+        }];
+      };*/
+      "allow-all-${region}" = {
+        inherit region accessKeyId;
+        description = "Catch all";
+        rules = [{
+          protocol = "-1"; # All traffic
+          sourceIp = "0.0.0.0/0";
+          fromPort = 0;
+          toPort = 65535;
+        }];
+      };
+    });
   };
 }

--- a/lib.nix
+++ b/lib.nix
@@ -14,7 +14,8 @@ in lib // (rec {
 
   # TODO: sanity check there's no duplicate nodes for same index
   # https://github.com/NixOS/nixops/blob/e2015bbfcbcf7594824755e39f838d7aab258b6e/nix/eval-machine-info.nix#L173
-  mergeNodes = nodes: lib.foldAttrs (a: b: a) [] nodes;
+  mergeNodes = mergeAttrs;
+  mergeAttrs = nodes: lib.foldAttrs (a: b: a) [] nodes;
 
   mkNodes = nodes: config: lib.mapAttrs (name: value: config value.i value.region) nodes;
   mkNodeIPs = nodes: accessKeyId: lib.mapAttrs' (name: value:

--- a/modules/amazon-base.nix
+++ b/modules/amazon-base.nix
@@ -7,7 +7,7 @@ with (import ./../lib.nix);
  deployment.ec2.instanceType = mkDefault "t2.large";
  deployment.ec2.region = mkDefault region;
  deployment.ec2.keyPair = mkDefault (resources.ec2KeyPairs.${keypairFor region});
- deployment.ec2.securityGroups = mkDefault ["cardano-deployment"];
-deployment.ec2.accessKeyId = mkDefault "cardano-deployer";
+ deployment.ec2.securityGroups = mkDefault [resources.ec2SecurityGroups."allow-all-${config.deployment.ec2.region}" ];
+ deployment.ec2.accessKeyId = mkDefault "cardano-deployer";
  deployment.ec2.ebsInitialRootDiskSize = mkDefault 30;
 }


### PR DESCRIPTION
This also changes `enableP2P` to be respected only in development since it doesn't make sense in production.

TODO:

- [x] this allows just all TCP, we should allow all traffic