### PR TITLE
[DEVOPS-123]  Provide NIX_PATH in nix-shell; add override tools

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,13 @@ let
   prodMode = drv: overrideCabal drv (drv: {
     configureFlags = [ "-f-asserts" "-f-dev-mode"];
   });
+
+  githubSrc     =      repo: rev: sha256:       pkgs.fetchgit  { url = "https://github.com/" + repo; rev = rev; sha256 = sha256; };
+  overC         =                               pkgs.haskell.lib.overrideCabal;
+  overCabal     = old:                    args: overC old (oldAttrs: (oldAttrs // args));
+  overGithub    = old: repo: rev: sha256: args: overC old ({ src = githubSrc repo rev sha256; }     // args);
+  overHackage   = old: version:   sha256: args: overC old ({ version = version; sha256 = sha256; } // args);
+
   socket-io-src = pkgs.fetchgit (removeAttrs (lib.importJSON ./pkgs/engine-io.json) ["date"]);
   cardano-sl-src = pkgs.fetchgit (removeAttrs (lib.importJSON ./pkgs/cardano-sl.json) ["date"]);
 in compiler.override {

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
     "owner":  "NixOS",
     "repo":   "nixpkgs",
-    "rev":    "464c79ea9f929d1237dbc2df878eedad91767a72",
-    "sha256": "05kkm978bfai3krsjn6h310xj7q0022bbh7a80kdizglqfkj8krw"
+    "rev":    "05126bc8503a37bfd2fe80867eb5b0bea287c633",
+    "sha256": "09bdc5faqdyzv6z8q9bvzs7k3fksxz5pmq4vk9xih7kp9xqv2ml0"
 }

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,6 @@ ghc       = ghcOrig.override (oldArgs: {
   let parent = (oldArgs.overrides or (_: _: {})) new old;
   in with new; parent // {
       intero         = overhub  old.intero "commercialhaskell/intero" "e546ea086d72b5bf8556727e2983930621c3cb3c" "1qv7l5ri3nysrpmnzfssw8wvdvz0f6bmymnz1agr66fplazid4pn" { doCheck = false; };
-      turtle_1_3_0   = doJailbreak old.turtle_1_3_0;
     };
   });
 
@@ -25,7 +24,7 @@ ghc       = ghcOrig.override (oldArgs: {
 ###
 drvf =
 { mkDerivation, stdenv, src ? ./.
-, base, turtle_1_3_0, cassava, vector, safe, aeson, yaml, lens-aeson
+, base, turtle, cassava, vector, safe, aeson, yaml, lens-aeson
 }:
 mkDerivation {
   pname = "iohk-nixops";
@@ -35,7 +34,7 @@ mkDerivation {
   isExecutable = true;
   doHaddock = false;
   executableHaskellDepends = [
-   base turtle_1_3_0 cassava vector safe aeson yaml lens-aeson
+   base turtle cassava vector safe aeson yaml lens-aeson
   ];
   # description  = "Visual mind assistant";
   license      = stdenv.lib.licenses.agpl3;

--- a/shell.nix
+++ b/shell.nix
@@ -6,13 +6,14 @@ nixpkgs       = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builti
 pkgs          = import nixpkgs {};
 compiler      = pkgs.haskell.packages."${ghcVer}";
 
+ghcOrig       = import ./default.nix { inherit pkgs compiler; };
 
-ghcOrig   = import ./default.nix { inherit pkgs compiler; };
-overcabal = pkgs.haskell.lib.overrideCabal;
-hubsrc    =      repo: rev: sha256:       pkgs.fetchgit { url = "https://github.com/" + repo; rev = rev; sha256 = sha256; };
-overc     = old:                    args: overcabal old (oldAttrs: (oldAttrs // args));
-overhub   = old: repo: rev: sha256: args: overc old ({ src = hubsrc repo rev sha256; }       // args);
-overhage  = old: version:   sha256: args: overc old ({ version = version; sha256 = sha256; } // args);
+githubSrc     =      repo: rev: sha256:       pkgs.fetchgit  { url = "https://github.com/" + repo; rev = rev; sha256 = sha256; };
+overC         =                               pkgs.haskell.lib.overrideCabal;
+overCabal     = old:                    args: overC old (oldAttrs: (oldAttrs // args));
+overGithub    = old: repo: rev: sha256: args: overC old ({ src = githubSrc repo rev sha256; }     // args);
+overHackage   = old: version:   sha256: args: overC old ({ version = version; sha256 = sha256; } // args);
+
 ghc       = ghcOrig.override (oldArgs: {
   overrides = with pkgs.haskell.lib; new: old:
   let parent = (oldArgs.overrides or (_: _: {})) new old;

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,8 @@ ghc       = ghcOrig.override (oldArgs: {
   overrides = with pkgs.haskell.lib; new: old:
   let parent = (oldArgs.overrides or (_: _: {})) new old;
   in with new; parent // {
-      intero         = overhub  old.intero "commercialhaskell/intero" "e546ea086d72b5bf8556727e2983930621c3cb3c" "1qv7l5ri3nysrpmnzfssw8wvdvz0f6bmymnz1agr66fplazid4pn" { doCheck = false; };
+      intero         = overGithub  old.intero "commercialhaskell/intero"
+                       "e546ea086d72b5bf8556727e2983930621c3cb3c" "1qv7l5ri3nysrpmnzfssw8wvdvz0f6bmymnz1agr66fplazid4pn" { doCheck = false; };
     };
   });
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,11 @@
-{ pkgs     ? import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json))) {}
-, compiler ? pkgs.haskell.packages.ghc802
+{ ghcVer   ? "ghc802"
 , intero   ? false
-}:
+}: let
 
-let
+nixpkgs       = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json));
+pkgs          = import nixpkgs {};
+compiler      = pkgs.haskell.packages."${ghcVer}";
+
 
 ghcOrig   = import ./default.nix { inherit pkgs compiler; };
 overcabal = pkgs.haskell.lib.overrideCabal;
@@ -36,8 +38,12 @@ mkDerivation {
   executableHaskellDepends = [
    base turtle cassava vector safe aeson yaml lens-aeson
   ];
-  # description  = "Visual mind assistant";
-  license      = stdenv.lib.licenses.agpl3;
+  shellHook =
+  ''
+    export NIX_PATH=nixpkgs=${nixpkgs}
+    echo   NIX_PATH set to $NIX_PATH
+  '';
+  license      = stdenv.lib.licenses.mit;
 };
 
 drv = (pkgs.haskell.lib.addBuildTools


### PR DESCRIPTION
This pursues https://issues.serokell.io/issue/DEVOPS-132, by removing one point of `<nixpkgs>` variance:  environment.