### PR TITLE
[DEVOPS-142]  Implement a global --debug flag for all deployment scripts

### DIFF
--- a/CardanoCSL.hs
+++ b/CardanoCSL.hs
@@ -71,14 +71,14 @@ subparser =
   <|> subcommand "ami" "Build ami" (pure AMI)
   <|> subcommand "generate-ipdht" "Generate IP/DHT mappings for wallet use" (pure GenerateIPDHTMappings)
 
-parser :: Parser (FilePath, Command)
-parser = (,) <$> optPath "config" 'c' "Configuration file"
+parser :: Parser (Options, Command)
+parser = (,) <$> optionsParser
              <*> subparser
 
 main :: IO ()
 main = do
-  (configFile, command) <- options "Helper CLI around NixOps to run experiments" parser
-  Just c <- decodeFile $ encodeString configFile
+  (opts@Options{..}, command) <- options "Helper CLI around NixOps to run experiments" parser
+  Just c <- decodeFile $ encodeString oConfigFile
   --dat <- fmap toNodesInfo <$> info c
   dat <- getSmartGenCmd c
   TIO.putStrLn $ T.pack $ show dat
@@ -86,12 +86,12 @@ main = do
       isNode _ = False
       getNodeNames' = filter isNode <$> getNodeNames c
   case command of
-    Deploy -> deploy c
-    Create -> create c
-    Destroy -> destroy c
-    FromScratch -> fromscratch c
     CheckStatus -> checkstatus c
     RunExperiment -> getNodeNames' >>= runexperiment c
+    Deploy         -> deploy      opts c
+    Create         -> create      opts c
+    Destroy        -> destroy     opts c
+    FromScratch    -> fromscratch opts c
     PostExperiment -> postexperiment c
     Build -> build c
     DumpLogs {..} -> getNodeNames' >>= void . dumpLogs c withProf

--- a/CardanoCSL.hs
+++ b/CardanoCSL.hs
@@ -86,12 +86,12 @@ main = do
       isNode _ = False
       getNodeNames' = filter isNode <$> getNodeNames c
   case command of
-    CheckStatus -> checkstatus c
-    RunExperiment -> getNodeNames' >>= runexperiment c
     Deploy         -> deploy      opts c
     Create         -> create      opts c
     Destroy        -> destroy     opts c
     FromScratch    -> fromscratch opts c
+    CheckStatus    -> checkstatus c
+    RunExperiment  -> getNodeNames' >>= runexperiment c
     PostExperiment -> postexperiment c
     Build -> build c
     DumpLogs {..} -> getNodeNames' >>= void . dumpLogs c withProf

--- a/Infra.hs
+++ b/Infra.hs
@@ -31,20 +31,22 @@ data Command =
   | CheckStatus
   deriving (Show)
 
-parser :: Parser Command
+parser :: Parser (Options, Command)
 parser =
-      subcommand "create" "Create a new cluster" (pure Create)
-  <|> subcommand "deploy" "Deploy the whole cluster" (pure Deploy)
-  <|> subcommand "destroy" "Destroy the whole cluster" (pure Destroy)
-  <|> subcommand "fromscratch" "Destroy, Delete, Create, Deploy" (pure FromScratch)
-  <|> subcommand "checkstatus" "Check if nodes are accessible via ssh and reboot if they timeout" (pure CheckStatus)
+  (,)
+  <$> optionsParser
+  <*> (subcommand "create" "Create a new cluster" (pure Create)
+   <|> subcommand "deploy" "Deploy the whole cluster" (pure Deploy)
+   <|> subcommand "destroy" "Destroy the whole cluster" (pure Destroy)
+   <|> subcommand "fromscratch" "Destroy, Delete, Create, Deploy" (pure FromScratch)
+   <|> subcommand "checkstatus" "Check if nodes are accessible via ssh and reboot if they timeout" (pure CheckStatus))
 
 main :: IO ()
 main = do
-  command <- options "Helper CLI around NixOps to run experiments" parser
+  (opts, command) <- options "Helper CLI around NixOps to run experiments" parser
   case command of
-    Create -> create c
-    Deploy -> deploy c
-    Destroy -> destroy c
-    FromScratch -> fromscratch c
+    Create      -> create      opts c
+    Deploy      -> deploy      opts c
+    Destroy     -> destroy     opts c
+    FromScratch -> fromscratch opts c
     CheckStatus -> checkstatus c

--- a/Infra.hs
+++ b/Infra.hs
@@ -23,8 +23,8 @@ c = NixOpsConfig
   , nixPath = "nixpkgs=https://github.com/NixOS/nixpkgs/archive/05126bc8503a37bfd2fe80867eb5b0bea287c633.tar.gz"
   }
 
-data Command =
-    Create
+data Command
+  = Create
   | Deploy
   | Destroy
   | FromScratch

--- a/TimeWarp.hs
+++ b/TimeWarp.hs
@@ -2,7 +2,7 @@
 #! nix-shell -j 4 -i runhaskell -p 'pkgs.haskellPackages.ghcWithPackages (hp: with hp; [ turtle cassava vector safe yaml ])'
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/f2c4af4e3bd9ecd4b1cf494270eae5fd3ca9e68c.tar.gz
 
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards #-}
 
 import Control.Monad (forM_)
 import Data.Monoid ((<>))
@@ -36,8 +36,8 @@ subparser =
   <|> subcommand "runexperiment" "Deploy cluster and perform measurements" (pure RunExperiment)
 
 
-parser :: Parser (FilePath, Command)
-parser = (,) <$> optPath "config" 'c' "Configuration file"
+parser :: Parser (Options, Command)
+parser = (,) <$> optionsParser
              <*> subparser
 
 
@@ -48,15 +48,15 @@ deployment = " deployments/timewarp.nix "
 
 main :: IO ()
 main = do
-  (configFile, command) <- options "Helper CLI around NixOps to run experiments" parser
-  Just c <- decodeFile $ encodeString configFile
+  (opts@Options{..}, command) <- options "Helper CLI around NixOps to run experiments" parser
+  Just c <- decodeFile $ encodeString oConfigFile
   case command of
-    Deploy -> deploy c
-    Destroy -> destroy c
-    FromScratch -> fromscratch c
     CheckStatus -> checkstatus c
     RunExperiment -> runexperiment c
     Build -> build c
+    Deploy        -> deploy        opts c
+    Destroy       -> destroy       opts c
+    FromScratch   -> fromscratch   opts c
     -- TODO: invoke nixops with passed parameters
 
 runexperiment :: NixOpsConfig -> IO ()

--- a/TimeWarp.hs
+++ b/TimeWarp.hs
@@ -51,12 +51,12 @@ main = do
   (opts@Options{..}, command) <- options "Helper CLI around NixOps to run experiments" parser
   Just c <- decodeFile $ encodeString oConfigFile
   case command of
-    CheckStatus -> checkstatus c
-    RunExperiment -> runexperiment c
-    Build -> build c
     Deploy        -> deploy        opts c
     Destroy       -> destroy       opts c
     FromScratch   -> fromscratch   opts c
+    CheckStatus   -> checkstatus        c
+    RunExperiment -> runexperiment      c
+    Build         -> build c
     -- TODO: invoke nixops with passed parameters
 
 runexperiment :: NixOpsConfig -> IO ()


### PR DESCRIPTION
This is to:

1. allow `--debug` passed to most `nixops` commands
2. facilitate easier future options definitions