### PR TITLE
[DEVOPS-108] Improve DataDog monitors.

### DIFF
--- a/deployments/cardano-nodes-env-production.nix
+++ b/deployments/cardano-nodes-env-production.nix
@@ -11,16 +11,7 @@ in {
       disk = mkMonitor disk_monitor;
       ram = mkMonitor ram_monitor;
       ntp = mkMonitor ntp_monitor;
-
-      cardano_node_process_monitor = mkMonitor {
-        name = "cardano-node process is down";
-        type = "service check";
-        query = _config: "\"process.up\".over(\"cardano-node\",\"process:cardano-node\").by(\"host\",\"process\").last(2).count_by_status()";
-        monitorOptions.thresholds = {
-          warning = 1;
-          critical = 1;
-        };
-      };
+      cardano_node_process = mkMonitor cardano_node_process_monitor;
     });
   };
 } // (mkNodes nodes (i: r: nodeProdConf))

--- a/modules/datadog-monitors.nix
+++ b/modules/datadog-monitors.nix
@@ -1,18 +1,32 @@
 with (import ./../lib.nix);
 
 rec {
+  alertMessage = msg: ''
+    {{#is_alert}}
+    ${msg}
+    {{/is_alert}}
+  '';
+  warningMessage = msg: ''
+    {{#is_warning}}
+    ${msg}
+    {{/is_warning}}
+  '';
+  pagerDutyCritical = "@pagerduty-Datadog_Critical";
+  pagerDutyNonCritical = "@pagerduty-Datadog_Non-Critical";
+  pagerDutyPolicy = {
+    normal = ''
+      ${alertMessage pagerDutyCritical}
+      ${warningMessage pagerDutyNonCritical}
+    '';
+    nonCritical = ''
+      ${alertMessage pagerDutyNonCritical}
+      ${warningMessage pagerDutyNonCritical}
+    '';
+  };
+
   baseMonitor = {
     apiKey = fileContents ./../static/datadog-api.secret;
     appKey = fileContents ./../static/datadog-application.secret;
-    message = ''
-      {{#is_alert}}
-      @pagerduty-Datadog_Critical
-      {{/is_alert}}
-
-      {{#is_warning}}
-      @pagerduty-Datadog_Non-Critical
-      {{/is_warning}}
-    '';
     monitorOptions = {
       renotify_interval = 60;
       include_tags = true;
@@ -23,16 +37,11 @@ rec {
     };
   };
 
-  mkMonitor = { name, type, query, message ? "", monitorOptions ? {} }:
+  mkMonitor = { name, type, query, message ? pagerDutyPolicy.normal, monitorOptions ? {} }:
     { config, ... }:
     baseMonitor // {
-      inherit name type;
+      inherit name type message;
       query = query config;
-      message = ''
-        ${message}
-
-        ${baseMonitor.message}
-      '';
       monitorOptions = builtins.toJSON (baseMonitor.monitorOptions // monitorOptions);
     };
 
@@ -40,7 +49,7 @@ rec {
   cpu_monitor = {
     name = "High CPU usage";
     type = "metric alert";
-    query = config: "avg(last_5m):avg:system.load.norm.1{host:${config.deployment.name}.machine} by {host} > 0.9";
+    query = config: "avg(last_5m):avg:system.load.norm.1{env:${config.deployment.name}} by {host} > 0.9";
     monitorOptions.thresholds = {
       warning = "0.75";
       critical = "0.9";
@@ -50,7 +59,7 @@ rec {
   disk_monitor = {
     name = "High disk usage";
     type = "metric alert";
-    query = config: "max(last_5m):avg:system.disk.in_use{host:${config.deployment.name}.machine} by {host} > 0.9";
+    query = config: "max(last_5m):avg:system.disk.in_use{env:${config.deployment.name}} by {host} > 0.9";
     monitorOptions.thresholds = {
       warning = "0.8";
       critical = "0.9";
@@ -60,7 +69,7 @@ rec {
   ram_monitor = {
     name = "RAM is running low";
     type = "metric alert";
-    query = config: "avg(last_1m):avg:system.mem.pct_usable{host:${config.deployment.name}.machine} by {host} < 0.2";
+    query = config: "avg(last_1m):avg:system.mem.pct_usable{env:${config.deployment.name}} by {host} < 0.2";
     monitorOptions.thresholds = {
       warning = "0.5";
       critical = "0.2";
@@ -70,9 +79,20 @@ rec {
   ntp_monitor = {
     name = "Clock out of sync with NTP";
     type = "service check";
-    query = config: "\"ntp.in_sync\".over(\"{host:${config.deployment.name}.machine}\").by(\"host\").last(2).count_by_status()";
+    query = config: "\"ntp.in_sync\".over(\"{env:${config.deployment.name}}\").by(\"host\").last(2).count_by_status()";
     monitorOptions.thresholds = {
       critical = 1;
+    };
+  };
+
+  cardano_node_process_monitor = {
+    name = "cardano-node process is down";
+    type = "service check";
+    query = config: "\"process.up\".over(\"env:${config.deployment.name}\",\"process:cardano-node\").by(\"host\",\"process\").last(5).count_by_status()";
+    monitorOptions.thresholds = {
+      warning = 2;
+      critical = 4;
+      ok = 2;
     };
   };
 }


### PR DESCRIPTION
- Fix default monitor scopes so they use the appropriate DataDog tag.
- Increase consecutive failure thresholds for process monitor. When it
  was set to 1 consecutive failure, scheduled restarts could cause
  false alarms.
- Add `pagerDutyPolicy` so urgency can be changed per deployment
  environment.