### PR TITLE
[DEVOPS-123] nixpkgs unification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - mkdir keys
   - touch keys/key{0,1,2,3,4,5,6,7,8,9,10,11,12,13,41}.sk
 script:
-  - echo $NIX_PATH
+  - ./scripts/find-all-revisions.sh
   - nixops --version
   # check all scripts compile
   - ./CardanoCSL.hs --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: nix
 
 install:
   - source scripts/set_nixpath.sh
-  - echo "binary-caches = https://cache.nixos.org https://hydra.iohk.io" | sudo tee -a /etc/nix/nix.conf
-  - echo "binary-cache-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" | sudo tee -a /etc/nix/nix.conf
+  - cat /etc/nix/nix.conf > ~/nix.conf
+  - echo "binary-caches = https://cache.nixos.org https://hydra.iohk.io" >> ~/nix.conf
+  - echo "binary-cache-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" >> ~/nix.conf
+  - export NIX_CONF_DIR=~
   - nix-env -iA nixopsUnstable -f '<nixpkgs>'
   - touch static/datadog-{api,application}.secret
   - echo "secret" > static/tarsnap-cardano-deployer.secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: nix
 
 install:
   - source scripts/set_nixpath.sh
+  - echo "binary-caches = https://cache.nixos.org https://hydra.iohk.io" | sudo tee -a /etc/nix/nix.conf
+  - echo "binary-cache-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" | sudo tee -a /etc/nix/nix.conf
   - nix-env -iA nixopsUnstable -f '<nixpkgs>'
   - touch static/datadog-{api,application}.secret
   - echo "secret" > static/tarsnap-cardano-deployer.secret

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: nix
 
-env:
-  NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/c0b1e8a5fb174cd405dcca9f7fec275714ad9f4b.tar.gz
-
 install:
+  - source scripts/set_nixpath.sh
   - nix-env -iA nixopsUnstable -f '<nixpkgs>'
   - touch static/datadog-{api,application}.secret
   - echo "secret" > static/tarsnap-cardano-deployer.secret
   - mkdir keys
   - touch keys/key{0,1,2,3,4,5,6,7,8,9,10,11,12,13,41}.sk
 script:
+  - echo $NIX_PATH
   - nixops --version
   # check all scripts compile
   - ./CardanoCSL.hs --help
@@ -18,6 +17,7 @@ script:
   - ./scripts/ctl.hs --help
   # check all packages build
   - nix-instantiate jobsets/cardano.nix --show-trace
+  - nix-shell --run "echo it works"
   # check deploy evaluations
   - nixops create deployments/{cardano-nodes,cardano-nodes-target-aws,cardano-nodes-env-production,cardano-explorer,cardano-explorer-target-aws,cardano-explorer-env-production,report-server,report-server-target-aws,report-server-env-production,keypairs}.nix -d csl-production
   - nixops create deployments/{cardano-nodes,cardano-nodes-target-aws,cardano-nodes-env-staging,cardano-explorer,cardano-explorer-target-aws,cardano-explorer-env-staging,report-server,report-server-target-aws,report-server-env-staging,keypairs}.nix -d csl-staging

--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -1,0 +1,1 @@
+(import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json))

--- a/fetch-nixpkgs.nix
+++ b/fetch-nixpkgs.nix
@@ -1,1 +1,2 @@
-(import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json))
+# to manualy fetch things with nix-build and confirm the hash in the json
+(import ./lib.nix).fetchNixPkgs

--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -1,5 +1,5 @@
 let
-  fixedNixpkgs = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ../nixpkgs-src.json));
+  fixedNixpkgs = (import ../lib.nix).fetchNixPkgs;
 in { pkgs ? (import fixedNixpkgs {}), supportedSystems ? [ "x86_64-linux" ] }:
 
 

--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -1,10 +1,13 @@
-{ pkgs ? (import <nixpkgs> {}), supportedSystems ? [ "x86_64-linux" ] }:
+{ pkgs' ? (import <nixpkgs> {}), supportedSystems ? [ "x86_64-linux" ] }:
 
-with pkgs;
 
 let
+  pkgs = if (builtins.getEnv "NIX_PATH_LOCKED" == "1") then
+    pkgs'
+  else
+    import (import ../lib.nix).fetchNixPkgs {};
   iohkpkgs = import ./../default.nix {};
-in rec {
+in with pkgs; rec {
   inherit (iohkpkgs) cardano-report-server-static cardano-sl-static cardano-sl-explorer-static cardano-sl;
   stack2nix = iohkpkgs.callPackage ./../pkgs/stack2nix.nix {};
   cardano-node-image = (import <nixpkgs/nixos/lib/eval-config.nix> {

--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -1,12 +1,10 @@
-{ pkgs' ? (import <nixpkgs> {}), supportedSystems ? [ "x86_64-linux" ] }:
+let
+  fixedNixpkgs = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ../nixpkgs-src.json));
+in { pkgs ? (import fixedNixpkgs {}), supportedSystems ? [ "x86_64-linux" ] }:
 
 
 let
-  pkgs = if (builtins.getEnv "NIX_PATH_LOCKED" == "1") then
-    pkgs'
-  else
-    import (import ../lib.nix).fetchNixPkgs {};
-  iohkpkgs = import ./../default.nix {};
+  iohkpkgs = import ./../default.nix { inherit pkgs; };
 in with pkgs; rec {
   inherit (iohkpkgs) cardano-report-server-static cardano-sl-static cardano-sl-explorer-static cardano-sl;
   stack2nix = iohkpkgs.callPackage ./../pkgs/stack2nix.nix {};

--- a/lib.nix
+++ b/lib.nix
@@ -25,10 +25,7 @@ in lib // (rec {
     ) nodes;
 
   # fetch nixpkgs and give the expected hash
-  fetchNixPkgs = let
-    nixpkgsSrc = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
-  #in builtins.fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsSrc.rev}.tar.gz"; inherit (nixpkgsSrc) sha256; };
-  in (import <nixpkgs> {}).fetchFromGitHub nixpkgsSrc;
+  fetchNixPkgs = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json));
 
   # Parse peers from a file
   #

--- a/lib.nix
+++ b/lib.nix
@@ -24,6 +24,12 @@ in lib // (rec {
       }
     ) nodes;
 
+  # fetch nixpkgs and give the expected hash
+  fetchNixPkgs = let
+    nixpkgsSrc = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
+  #in builtins.fetchTarball { url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsSrc.rev}.tar.gz"; inherit (nixpkgsSrc) sha256; };
+  in (import <nixpkgs> {}).fetchFromGitHub nixpkgsSrc;
+
   # Parse peers from a file
   #
   # > peersFromFile ./peers.txt

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -41,13 +41,18 @@ with (import ./../lib.nix);
 
     buildCores = 0;
 
-    nixPath = ["nixpkgs=http://nixos.org/channels/nixos-17.03/nixexprs.tar.xz"];
+    nixPath = [ "nixpkgs=/run/current-system/nixpkgs" ];
 
     # use our hydra builds
     trustedBinaryCaches = [ "https://cache.nixos.org" "https://hydra.iohk.io" ];
     binaryCaches = trustedBinaryCaches;
     binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
   };
+  system.extraSystemBuilderCmds = let
+    setNixpkgs = pkgs.fetchFromGitHub (builtins.fromJSON (builtins.readFile ./../nixpkgs-src.json));
+  in ''
+    ln -sv ${setNixpkgs} $out/nixpkgs
+  '';
 
   # Mosh
   networking.firewall.allowedUDPPortRanges = [

--- a/pkgs/generate.sh
+++ b/pkgs/generate.sh
@@ -1,14 +1,18 @@
-#!/usr/bin/env nix-shell
-#! nix-shell -j 4 -i bash -p pkgs.cabal2nix pkgs.nix-prefetch-scripts pkgs.coreutils pkgs.cabal-install
-#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/c0b1e8a5fb174cd405dcca9f7fec275714ad9f4b.tar.gz
+#!/bin/sh
+
+function runInShell {
+  nix-shell -j 4 -p cabal2nix nix-prefetch-scripts coreutils cabal-install stack --run "$*"
+}
 
 set -xe
 
 # Get relative path to script directory
 scriptDir=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
 
+source ${scriptDir}/../scripts/set_nixpath.sh
+
 # Generate stack2nix Nix package
-cabal2nix \
+runInShell cabal2nix \
   --no-check \
   --revision 8f087b92f83be078e8cfe86fb243121dca4601ba \
   https://github.com/input-output-hk/stack2nix.git > $scriptDir/stack2nix.nix
@@ -17,12 +21,12 @@ cabal2nix \
 nix-build -E "with import <nixpkgs> {}; haskell.packages.ghc802.callPackage ${scriptDir}/stack2nix.nix {}" -o $scriptDir/stack2nix
 
 # Generate explorer until it's merged with cardano-sl repo
-cabal2nix \
+runInShell cabal2nix \
   --no-check \
   --revision 982ac2dd3efeca6fd7ebc1df11e9d1bf628c1700 \
   https://github.com/input-output-hk/cardano-sl-explorer.git > $scriptDir/cardano-sl-explorer.nix
 
 # Generate cardano-sl package set
-$scriptDir/stack2nix/bin/stack2nix \
+runInShell $scriptDir/stack2nix/bin/stack2nix \
   --revision 4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c \
   https://github.com/input-output-hk/cardano-sl.git > $scriptDir/default.nix

--- a/scripts/find-all-revisions.sh
+++ b/scripts/find-all-revisions.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+find . -type f '!' -path '*/.git/*' '!' -path ./pkgs/default.nix -print0 | xargs -0 egrep --color '[^a-z0-9][a-z0-9]{40}[^a-z0-9]'
+

--- a/scripts/generate-explorer-frontend.sh
+++ b/scripts/generate-explorer-frontend.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p git
+#!nix-shell -i bash -p git jq
 
-export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/7648f528de9917933bc104359c9a507c6622925c.tar.gz
+set -euo pipefail
+
+source scripts/set_nixpath.sh
 
 if [ ! -d "cardano-sl-explorer" ]; then
   git clone https://github.com/input-output-hk/cardano-sl-explorer.git

--- a/scripts/set_nixpath.sh
+++ b/scripts/set_nixpath.sh
@@ -1,0 +1,2 @@
+export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(jq .rev < nixpkgs-src.json -r).tar.gz
+export NIX_PATH_LOCKED=1

--- a/scripts/set_nixpath.sh
+++ b/scripts/set_nixpath.sh
@@ -1,2 +1,6 @@
-export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(jq .rev < nixpkgs-src.json -r).tar.gz
-export NIX_PATH_LOCKED=1
+update_NIX_PATH() {
+  local scriptDir=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
+  export NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/$(jq .rev < ${scriptDir}/../nixpkgs-src.json -r).tar.gz
+  export NIX_PATH_LOCKED=1
+}
+update_NIX_PATH

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,8 @@
 , intero   ? false
 }: let
 
-nixpkgs   = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json));
+lib       = import ./lib.nix;
+nixpkgs   = lib.fetchNixPkgs;
 pkgs      = import nixpkgs {};
 compiler  = pkgs.haskell.packages."${ghcVer}";
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,10 @@
-{ pkgs     ? import ((import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json))) {}
-, compiler ? pkgs.haskell.packages.ghc802
+{ ghcVer   ? "ghc802"
 , intero   ? false
-}:
+}: let
 
-let
+nixpkgs   = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json));
+pkgs      = import nixpkgs {};
+compiler  = pkgs.haskell.packages."${ghcVer}";
 
 ghcOrig   = import ./default.nix { inherit pkgs compiler; };
 overcabal = pkgs.haskell.lib.overrideCabal;
@@ -37,8 +38,12 @@ mkDerivation {
   executableHaskellDepends = [
    base turtle cassava vector safe aeson yaml lens-aeson
   ];
-  # description  = "Visual mind assistant";
-  license      = stdenv.lib.licenses.agpl3;
+  shellHook =
+  ''
+    export NIX_PATH=nixpkgs=${nixpkgs}
+    echo   NIX_PATH set to $NIX_PATH
+  '';
+  license      = stdenv.lib.licenses.mit;
 };
 
 drv = (pkgs.haskell.lib.addBuildTools

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? (import <nixpkgs> {}), supportedSystems ? [ "x86_64-linux" ] }:
 
 with pkgs;
-with lib;
+with pkgs.lib;
 
 let
   forAllSystems = genAttrs supportedSystems;


### PR DESCRIPTION
most parts of the project now obey nixpkgs-src.json

the #!nix-shell stuff cant be configured to read from a file, so they now expect the user to `source scripts/set_nixpath.sh` before being ran, that will probably change after DEVOPS-22

still needs a travis check to ensure no new paths get added