### PR TITLE
[DEVOPS-74]  Deploy EKG->statsd->Datadog stats

### DIFF
--- a/modules/cardano-node-aws.nix
+++ b/modules/cardano-node-aws.nix
@@ -19,6 +19,7 @@ testIndex: region:
         );
         publicIP = if options.networking.publicIPv4.isDefined then config.networking.publicIPv4 else null;
         privateIP = if options.networking.privateIPv4.isDefined then config.networking.privateIPv4 else "0.0.0.0";
+        ekgSink = "127.0.0.1:8125";
       };
 
       # TODO: DEVOPS-8

--- a/modules/cardano-node-aws.nix
+++ b/modules/cardano-node-aws.nix
@@ -19,7 +19,7 @@ testIndex: region:
         );
         publicIP = if options.networking.publicIPv4.isDefined then config.networking.publicIPv4 else null;
         privateIP = if options.networking.privateIPv4.isDefined then config.networking.privateIPv4 else "0.0.0.0";
-        ekgSink = "127.0.0.1:8125";
+        statsdServer = "127.0.0.1:8125";
       };
 
       # TODO: DEVOPS-8

--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -44,6 +44,7 @@ let
        then "--bitcoin-distr \"${distributionParam}\""
        else "--flat-distr \"${distributionParam}\""))
     (optionalString cfg.jsonLog "--json-log ${stateDir}/jsonLog.json")
+    (optionalString (cfg.ekgSink != null) "--metrics +RTS -T -RTS --statsd-server ${cfg.ekgSink}")
     "--kademlia-id ${cfg.dhtKey}"
     (optionalString cfg.productionMode "--keyfile ${stateDir}key${toString (cfg.testIndex + 1)}.sk")
     (optionalString (cfg.productionMode && cfg.systemStart != 0) "--system-start ${toString cfg.systemStart}")
@@ -87,6 +88,11 @@ in {
       slotDuration = mkOption { type = types.int; };
       networkDiameter = mkOption { type = types.int; };
       mpcRelayInterval = mkOption { type = types.int; };
+      ekgSink = mkOption {
+        type = types.str;
+        description = "IP:Port of the EKG telemetry sink";
+        default = null;
+      };
 
       stats = mkOption { type = types.bool; default = false; };
       jsonLog = mkOption { type = types.bool; default = true; };

--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -44,7 +44,7 @@ let
        then "--bitcoin-distr \"${distributionParam}\""
        else "--flat-distr \"${distributionParam}\""))
     (optionalString cfg.jsonLog "--json-log ${stateDir}/jsonLog.json")
-    (optionalString (cfg.ekgSink != null) "--metrics +RTS -T -RTS --statsd-server ${cfg.ekgSink}")
+    (optionalString (cfg.statsdServer != null) "--metrics +RTS -T -RTS --statsd-server ${cfg.statsdServer}")
     "--kademlia-id ${cfg.dhtKey}"
     (optionalString cfg.productionMode "--keyfile ${stateDir}key${toString (cfg.testIndex + 1)}.sk")
     (optionalString (cfg.productionMode && cfg.systemStart != 0) "--system-start ${toString cfg.systemStart}")
@@ -88,7 +88,7 @@ in {
       slotDuration = mkOption { type = types.int; };
       networkDiameter = mkOption { type = types.int; };
       mpcRelayInterval = mkOption { type = types.int; };
-      ekgSink = mkOption {
+      statsdServer = mkOption {
         type = types.str;
         description = "IP:Port of the EKG telemetry sink";
         default = null;


### PR DESCRIPTION
This wires things up so that https://app.datadoghq.com/metric/explorer?live=true&page=0&is_auto=false&from_ts=1497925423905&to_ts=1497929023905&tile_size=m&exp_metric=rts.gc.gc_wall_ms&exp_scope=&exp_agg=avg&exp_row_type=metric can be observed : -)