### PR TITLE
fix hydra eval of the tests

### DIFF
--- a/tests/simple-node-nixops.nix
+++ b/tests/simple-node-nixops.nix
@@ -5,6 +5,7 @@ import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }: {
       imports = [ (import ../modules/cardano-node-config.nix 0 "") <nixops/nix/options.nix> <nixops/nix/resource.nix> ];
       services.cardano-node = {
         autoStart = true;
+        initialPeers = [];
       };
     };
   };

--- a/tests/simple-node.nix
+++ b/tests/simple-node.nix
@@ -5,6 +5,7 @@ import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }: {
       imports = [ (import ../modules/cardano-node-config.nix 0 "") ];
       services.cardano-node = {
         autoStart = true;
+        initialPeers = [];
       };
     };
   };


### PR DESCRIPTION
https://hydra.iohk.io/jobset/serokell/cardano-sl-staging#tabs-errors

```
in job ‘tests.simpleNode.x86_64-linux’:

Failed assertions:
- services.cardano-node.initialPeers must be set, a node needs at least one initial peer (testIndex: 0)
```