### PR TITLE
lock nixpkgs for pr building

### DIFF
--- a/jobsets/default.nix
+++ b/jobsets/default.nix
@@ -4,7 +4,9 @@
 
 let
   iohkNixopsUri = "https://github.com/input-output-hk/iohk-nixops.git";
-  pkgs = import nixpkgs {};
+  # when hydra builds PR's, it wont know the correct nixpkgs, this locks it in
+  fixedNixpkgs = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json));
+  pkgs = import fixedNixpkgs {};
   mkFetchGithub = value: {
     inherit value;
     type = "git";


### PR DESCRIPTION
when jobsets/default.nix generates a jobset for a PR, it won't know the correct nixpkgs to use
this patch makes the jobset fetch its own nixpkgs