### PR TITLE
also lock in the nixpkgs used for jobset eval

### DIFF
--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -1,9 +1,11 @@
-{ pkgs ? (import <nixpkgs> {}), supportedSystems ? [ "x86_64-linux" ] }:
+let
+  fixedNixpkgs = (import <nixpkgs> {}).fetchFromGitHub (builtins.fromJSON (builtins.readFile ../nixpkgs-src.json));
+in { pkgs ? (import fixedNixpkgs {}), supportedSystems ? [ "x86_64-linux" ] }:
 
 with pkgs;
 
 let
-  iohkpkgs = import ./../default.nix {};
+  iohkpkgs = import ./../default.nix { inherit pkgs; };
 in rec {
   inherit (iohkpkgs) cardano-report-server-static cardano-sl-static cardano-sl-explorer-static cardano-sl;
   stack2nix = iohkpkgs.callPackage ./../pkgs/stack2nix.nix {};

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
     "owner":  "NixOS",
     "repo":   "nixpkgs",
-    "rev":    "464c79ea9f929d1237dbc2df878eedad91767a72",
-    "sha256": "05kkm978bfai3krsjn6h310xj7q0022bbh7a80kdizglqfkj8krw"
+    "rev":    "9b948ea439ddbaa26740ce35543e7e35d2aa6d18",
+    "sha256": "17208in65j29xsipzfdy5hi0nmqf836i28bkcihh18qys7669bj8"
 }


### PR DESCRIPTION
PR #78 only covered the default.nix that generates jobsets