### PR TITLE
[DEVOPS-32] ensure pkgs/default.nix is up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - touch keys/key{0,1,2,3,4,5,6,7,8,9,10,11,12,13,41}.sk
 script:
   - ./scripts/find-all-revisions.sh
+  - nix-shell -p cabal2nix stack cabal-install ghc -Q -j 4 --run scripts/check-stack2nix.sh
   - nixops --version
   # check all scripts compile
   - iohk-ops --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ install:
   - echo "binary-caches = https://cache.nixos.org https://hydra.iohk.io" >> ~/nix.conf
   - echo "binary-cache-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" >> ~/nix.conf
   - export NIX_CONF_DIR=~
-  - nix-env -iA nixopsUnstable -f '<nixpkgs>'
+  - nix-env -f '<nixpkgs>' -i -A nixopsUnstable -A git
   - nix-env -iA iohk-ops       -f 'default.nix'
   - touch static/datadog-{api,application}.secret
   - echo "secret" > static/tarsnap-cardano-deployer.secret
   - mkdir keys
   - touch keys/key{0,1,2,3,4,5,6,7,8,9,10,11,12,13,41}.sk
 script:
+  - git --version
   - ./scripts/find-all-revisions.sh
   - nix-shell -p cabal2nix stack cabal-install ghc -Q -j 4 --run scripts/check-stack2nix.sh
   - nixops --version

--- a/cardano-sl-explorer-src.json
+++ b/cardano-sl-explorer-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl-explorer.git",
-  "rev": "982ac2dd3efeca6fd7ebc1df11e9d1bf628c1700",
-  "date": "2017-06-14T12:23:15+02:00",
-  "sha256": "0gia9zp5nhyqc4i4say4yf8w4r6im6syrxkd33prl0wq2j3y0337",
+  "rev": "c5bebf1b1f343f952182a598f5c9e625998b2b70",
+  "date": "2017-06-27T19:33:12+02:00",
+  "sha256": "1lm0a07vb1hqavrraq75ifscfhkrdgqsg62l1nmn86yiwpk40q8d",
   "fetchSubmodules": true
 }

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl.git",
-  "rev": "b70844676db4658553a1e0b258e9e1cc8469cc3a",
-  "date": "2017-06-22T17:14:39+03:00",
-  "sha256": "0jpvlw287gn0xasnv4kjl6xqqrg7camfwv92vmhqx6a7ay5srs8n",
+  "rev": "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d",
+  "date": "2017-06-29T14:54:09+02:00",
+  "sha256": "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w",
   "fetchSubmodules": true
 }

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ let
   });
 
   socket-io-src = pkgs.fetchgit (removeAttrs (importJSON ./pkgs/engine-io.json) ["date"]);
-in (import pkgs/default.nix { inherit pkgs compiler; }).override {
+  iohkpkgs = ((import pkgs/default.nix { inherit pkgs compiler; }).override {
   overrides = self: super: {
     cardano-sl-core = prodMode super.cardano-sl-core;
     cardano-sl = overrideCabal super.cardano-sl (drv: {
@@ -55,4 +55,10 @@ in (import pkgs/default.nix { inherit pkgs compiler; }).override {
     #enableLibraryProfiling = false;
     #});
   };
-}
+});
+  cabal2nixpkgs = rec {
+    # extra packages to expose, that have no relation to pkgs/default.nix
+    stack2nix = compiler.callPackage ./pkgs/stack2nix.nix {};
+    iohk-ops  = compiler.callPackage (import ./iohk) {};
+  };
+in iohkpkgs // cabal2nixpkgs

--- a/jobsets/cardano.nix
+++ b/jobsets/cardano.nix
@@ -6,8 +6,7 @@ in { pkgs ? (import fixedNixpkgs {}), supportedSystems ? [ "x86_64-linux" ] }:
 let
   iohkpkgs = import ./../default.nix { inherit pkgs; };
 in with pkgs; rec {
-  inherit (iohkpkgs) cardano-report-server-static cardano-sl-static cardano-sl-explorer-static cardano-sl iohk-ops;
-  stack2nix      = iohkpkgs.callPackage ./../pkgs/stack2nix.nix {};
+  inherit (iohkpkgs) cardano-report-server-static cardano-sl-static cardano-sl-explorer-static cardano-sl iohk-ops stack2nix;
   tests          = import ./../tests     { inherit pkgs supportedSystems; };
-  iohk-shell-env = import ./../shell.nix { inherit pkgs iohkpkgs stack2nix; };
+  iohk-shell-env = import ./../shell.nix { inherit pkgs iohkpkgs; };
 }

--- a/pkgs/cardano-sl-explorer.nix
+++ b/pkgs/cardano-sl-explorer.nix
@@ -16,8 +16,8 @@ mkDerivation {
   version = "0.1.0";
   src = fetchgit {
     url = "https://github.com/input-output-hk/cardano-sl-explorer.git";
-    sha256 = "0gia9zp5nhyqc4i4say4yf8w4r6im6syrxkd33prl0wq2j3y0337";
-    rev = "982ac2dd3efeca6fd7ebc1df11e9d1bf628c1700";
+    sha256 = "1lm0a07vb1hqavrraq75ifscfhkrdgqsg62l1nmn86yiwpk40q8d";
+    rev = "c5bebf1b1f343f952182a598f5c9e625998b2b70";
   };
   isLibrary = true;
   isExecutable = true;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -762,6 +762,8 @@ self: {
           pname = "authenticate-oauth";
           version = "1.6";
           sha256 = "0xc37yql79r9idjfdhzg85syrwwgaxggcv86myi6zq2pzl89yvfj";
+          revision = "1";
+          editedCabalFile = "ba9e93e7b949fa4799ae7b3cb302df38dc7fb0be0460803b6c48636317b2bcbb";
           libraryHaskellDepends = [
             base
             base64-bytestring
@@ -1318,8 +1320,8 @@ self: {
           version = "1.0.0";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-crypto";
-            sha256 = "1nxm0vlg9w841cc4gyy87jk4hvc3iimpjv2a9q6d99ri7v4ynnb4";
-            rev = "96adbd5aa9a906859deddf170f8762a9ed85c0c9";
+            sha256 = "0k8gm7fh0bypbd4mjb1kqwjp7mz2chl87haqx42av7z502gayy8w";
+            rev = "84f8c358463bbf6bb09168aac5ad990faa9d310a";
           };
           libraryHaskellDepends = [
             base
@@ -1423,14 +1425,14 @@ self: {
           description = "Reporting server for CSL";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      cardano-sl = callPackage ({ Glob, IfElse, QuickCheck, acid-state, aeson, ansi-terminal, ansi-wl-pprint, array, async, attoparsec, base, base58-bytestring, base64-bytestring, binary, binary-conduit, binary-orphans, bytestring, cardano-crypto, cardano-report-server, cardano-sl-core, cardano-sl-db, cardano-sl-godtossing, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cereal, conduit, containers, cpphs, criterion, cryptonite, cryptonite-openssl, data-default, deepseq, derive, deriving-compat, digest, directory, dlist, ed25519, either, ekg, ekg-core, ether, exceptions, fetchgit, file-embed, filelock, filepath, focus, foldl, formatting, gitrev, hashable, hashtables, hspec, http-client, http-client-tls, http-conduit, http-types, kademlia, lens, lifted-async, list-t, log-warper, lrucache, memory, mkDerivation, mmorph, monad-control, monad-loops, mono-traversable, mtl, neat-interpolation, network-info, network-transport, network-transport-tcp, node-sketch, optparse-applicative, optparse-simple, optparse-text, parsec, plutus-prototype, process, purescript-bridge, pvss, quickcheck-instances, random, random-shuffle, reflection, regex-tdfa, regex-tdfa-text, resourcet, rocksdb, safecopy, serokell-util, servant-multipart, servant-server_0_10, servant-swagger-ui, servant-swagger_1_1_2_1, servant_0_10, stdenv, stm, stm-containers, string-qq, swagger2, system-filepath, tagged, tar, template-haskell, temporary, text, text-format, th-lift-instances, time, time-units, transformers, transformers-base, transformers-lift, turtle, universum, unix, unordered-containers, vector, wai, wai-extra, wai-websockets, warp, websockets, wreq, yaml }:
+      cardano-sl = callPackage ({ Glob, IfElse, QuickCheck, acid-state, aeson, ansi-terminal, ansi-wl-pprint, array, async, attoparsec, base, base58-bytestring, base64-bytestring, binary, binary-conduit, binary-orphans, bytestring, cardano-crypto, cardano-report-server, cardano-sl-core, cardano-sl-db, cardano-sl-godtossing, cardano-sl-infra, cardano-sl-lrc, cardano-sl-ssc, cardano-sl-txp, cardano-sl-update, cereal, conduit, containers, cpphs, criterion, cryptonite, cryptonite-openssl, data-default, deepseq, derive, deriving-compat, digest, directory, dlist, ed25519, either, ekg, ekg-core, ekg-statsd, ether, exceptions, fetchgit, file-embed, filelock, filepath, focus, foldl, formatting, gitrev, hashable, hashtables, hspec, http-client, http-client-tls, http-conduit, http-types, kademlia, lens, lifted-async, list-t, log-warper, lrucache, memory, mkDerivation, mmorph, monad-control, monad-loops, mono-traversable, mtl, neat-interpolation, network-info, network-transport, network-transport-tcp, node-sketch, optparse-applicative, optparse-simple, optparse-text, parsec, plutus-prototype, process, purescript-bridge, pvss, quickcheck-instances, random, random-shuffle, reflection, regex-tdfa, regex-tdfa-text, resourcet, rocksdb, safecopy, serokell-util, servant-multipart, servant-server_0_10, servant-swagger-ui, servant-swagger_1_1_2_1, servant_0_10, stdenv, stm, stm-containers, string-qq, swagger2, system-filepath, tagged, tar, template-haskell, temporary, text, text-format, th-lift-instances, time, time-units, transformers, transformers-base, transformers-lift, turtle, universum, unix, unordered-containers, vector, versions, wai, wai-extra, wai-websockets, warp, websockets, wreq, yaml }:
       mkDerivation {
           pname = "cardano-sl";
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           isLibrary = true;
           isExecutable = true;
@@ -1471,6 +1473,7 @@ self: {
             ed25519
             ekg
             ekg-core
+            ekg-statsd
             ether
             exceptions
             file-embed
@@ -1535,6 +1538,7 @@ self: {
             unix
             unordered-containers
             vector
+            versions
             wai
             wai-extra
             wai-websockets
@@ -1621,6 +1625,7 @@ self: {
             bytestring
             cardano-sl-core
             cardano-sl-infra
+            cardano-sl-lrc
             cardano-sl-ssc
             cardano-sl-txp
             cardano-sl-update
@@ -1685,8 +1690,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1759,8 +1764,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/db; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1797,8 +1802,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/godtossing; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1839,19 +1844,20 @@ self: {
           description = "Cardano SL - GodTossing implementation of SSC";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-infra = callPackage ({ aeson, base, binary, bytestring, cardano-report-server, cardano-sl-core, cardano-sl-db, containers, cpphs, data-default, directory, ether, exceptions, fetchgit, filepath, formatting, hashable, kademlia, lens, list-t, log-warper, mkDerivation, mmorph, monad-control, mtl, network-info, network-transport-tcp, node-sketch, optparse-simple, parsec, reflection, serokell-util, stdenv, stm, stm-containers, tagged, template-haskell, temporary, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, wreq }:
+      cardano-sl-infra = callPackage ({ aeson, base, base64-bytestring, binary, bytestring, cardano-report-server, cardano-sl-core, cardano-sl-db, containers, cpphs, data-default, directory, ether, exceptions, fetchgit, filepath, formatting, hashable, kademlia, lens, list-t, log-warper, mkDerivation, mmorph, monad-control, mtl, network-info, network-transport-tcp, node-sketch, optparse-simple, parsec, reflection, serokell-util, stdenv, stm, stm-containers, tagged, template-haskell, temporary, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, wreq }:
       mkDerivation {
           pname = "cardano-sl-infra";
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/infra; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
             aeson
             base
+            base64-bytestring
             binary
             bytestring
             cardano-report-server
@@ -1907,8 +1913,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/lrc; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1937,8 +1943,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/ssc; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1968,17 +1974,18 @@ self: {
           description = "Cardano SL - the SSC class";
           license = stdenv.lib.licenses.mit;
         }) {};
-      cardano-sl-txp = callPackage ({ base, bytestring, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-update, containers, cpphs, data-default, derive, ether, fetchgit, formatting, hashable, lens, log-warper, mkDerivation, mtl, neat-interpolation, plutus-prototype, rocksdb, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, transformers, universum, unordered-containers, vector }:
+      cardano-sl-txp = callPackage ({ aeson, base, bytestring, cardano-sl-core, cardano-sl-db, cardano-sl-infra, cardano-sl-update, containers, cpphs, data-default, derive, ether, fetchgit, formatting, hashable, lens, lifted-base, log-warper, mkDerivation, monad-control, mtl, neat-interpolation, plutus-prototype, rocksdb, serokell-util, stdenv, stm, tagged, template-haskell, text, text-format, transformers, universum, unordered-containers, vector }:
       mkDerivation {
           pname = "cardano-sl-txp";
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/txp; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
+            aeson
             base
             bytestring
             cardano-sl-core
@@ -1992,7 +1999,9 @@ self: {
             formatting
             hashable
             lens
+            lifted-base
             log-warper
+            monad-control
             mtl
             neat-interpolation
             plutus-prototype
@@ -2020,8 +2029,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
-            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
+            sha256 = "09l50wq641r0x3b7g9v286s25hswjkm2dfcq0rajhfrcpd8ad32w";
+            rev = "86ab2c4dd5cfec64a0eca4ff996c02a40bbe733d";
           };
           postUnpack = "sourceRoot+=/update; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -3342,6 +3351,26 @@ self: {
           description = "JSON encoding of ekg metrics";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      ekg-statsd = callPackage ({ base, bytestring, ekg-core, mkDerivation, network, stdenv, text, time, unordered-containers }:
+      mkDerivation {
+          pname = "ekg-statsd";
+          version = "0.2.1.0";
+          sha256 = "04bpdmk3ma4fnylipg4hkq3jfkrw5f009vbns6vah0znawkpjhnh";
+          libraryHaskellDepends = [
+            base
+            bytestring
+            ekg-core
+            network
+            text
+            time
+            unordered-containers
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/tibbe/ekg-statsd";
+          description = "Push metrics to statsd";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
       entropy = callPackage ({ Cabal, base, bytestring, directory, filepath, mkDerivation, process, stdenv, unix }:
       mkDerivation {
           pname = "entropy";
@@ -3445,8 +3474,8 @@ self: {
           pname = "exceptions";
           version = "0.8.3";
           sha256 = "1gl7xzffsqmigam6zg0jsglncgzxqafld2p6kb7ccp9xirzdjsjd";
-          revision = "1";
-          editedCabalFile = "fc13261461399b8610d60468757f2fc0a62ed660dee998f4329e33dd76d2191b";
+          revision = "2";
+          editedCabalFile = "dc2b4ed2a3de646d8ff599ff972e25b3a1a5165ead3a46ff84a3d443814c85ee";
           libraryHaskellDepends = [
             base
             mtl
@@ -4507,8 +4536,8 @@ self: {
           pname = "insert-ordered-containers";
           version = "0.2.1.0";
           sha256 = "1612f455dw37da9g7bsd1s5kyi84mnr1ifnjw69892amyimi47fp";
-          revision = "2";
-          editedCabalFile = "972f14c0cf96728583b054eb2b26c2555438094685b562357ef12e1dc4cfc3eb";
+          revision = "3";
+          editedCabalFile = "6fdce987672b006226243aa17522b57ec7a9e1cab247802eddbdaa9dc5b06446";
           libraryHaskellDepends = [
             aeson
             base
@@ -5166,11 +5195,57 @@ self: {
           description = "Special functions and Chebyshev polynomials";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+      megaparsec = callPackage ({ QuickCheck, base, bytestring, containers, criterion, deepseq, exceptions, hspec, hspec-expectations, mkDerivation, mtl, scientific, stdenv, text, transformers, weigh }:
+      mkDerivation {
+          pname = "megaparsec";
+          version = "5.2.0";
+          sha256 = "0204x5bklgvfydap1a2y76aicnjfs33jh786y7w6vsb54fpafl62";
+          revision = "1";
+          editedCabalFile = "6faae587ac65280ee855936319116bbc3015bd96eadb1a5ea107852fa5c905aa";
+          libraryHaskellDepends = [
+            base
+            bytestring
+            containers
+            deepseq
+            exceptions
+            mtl
+            QuickCheck
+            scientific
+            text
+            transformers
+          ];
+          testHaskellDepends = [
+            base
+            bytestring
+            containers
+            exceptions
+            hspec
+            hspec-expectations
+            mtl
+            QuickCheck
+            scientific
+            text
+            transformers
+          ];
+          benchmarkHaskellDepends = [
+            base
+            criterion
+            deepseq
+            weigh
+          ];
+          doHaddock = false;
+          doCheck = false;
+          homepage = "https://github.com/mrkkrp/megaparsec";
+          description = "Monadic parser combinators";
+          license = stdenv.lib.licenses.bsd2;
+        }) {};
       memory = callPackage ({ base, bytestring, deepseq, foundation, ghc-prim, mkDerivation, stdenv, tasty, tasty-hunit, tasty-quickcheck }:
       mkDerivation {
           pname = "memory";
           version = "0.14.5";
           sha256 = "01d1bg8pkhw9mpyd7nm5zzpqv9kh9cj2fkd2ywvkay7np2r14820";
+          revision = "1";
+          editedCabalFile = "fe81cc9b260784b0e8e71d4953441fc97a575200732ded56ce25c0900744e605";
           libraryHaskellDepends = [
             base
             bytestring
@@ -5449,6 +5524,8 @@ self: {
           pname = "natural-transformation";
           version = "0.4";
           sha256 = "1by8xwjc23l6pa9l4iv7zp82dykpll3vc3hgxk0pgva724n8xhma";
+          revision = "1";
+          editedCabalFile = "83bedd2c7b0e4f8819753d2075036d99483d33bfdd3ba8889cf61fa05fa89ce9";
           libraryHaskellDepends = [
             base
           ];
@@ -5603,18 +5680,19 @@ self: {
           description = "URI manipulation";
           license = stdenv.lib.licenses.bsd3;
         }) {};
-      node-sketch = callPackage ({ QuickCheck, async, attoparsec, base, binary, bytestring, containers, criterion, data-default, deepseq, ekg, ekg-core, exceptions, fetchgit, formatting, hashable, hspec, kademlia, lens, log-warper, mkDerivation, mmorph, monad-control, mtl, mwc-random, network, network-transport, network-transport-inmemory, network-transport-tcp, quickcheck-instances, random, semigroups, serokell-util, statistics, stdenv, stm, text, text-format, time, time-units, transformers, transformers-base, universum, unordered-containers, vector }:
+      node-sketch = callPackage ({ QuickCheck, aeson, async, attoparsec, base, binary, bytestring, containers, criterion, data-default, deepseq, ekg, ekg-core, ether, exceptions, fetchgit, formatting, hashable, hspec, kademlia, lens, log-warper, mkDerivation, mmorph, monad-control, mtl, mwc-random, network, network-transport, network-transport-inmemory, network-transport-tcp, quickcheck-instances, random, semigroups, serokell-util, statistics, stdenv, stm, text, text-format, time, time-units, transformers, transformers-base, transformers-lift, universum, unordered-containers, vector }:
       mkDerivation {
           pname = "node-sketch";
           version = "0.1.2.0";
           src = fetchgit {
             url = "https://github.com/serokell/time-warp-nt.git";
-            sha256 = "1gb9zxc2xk48swjrwdqkhmqx6jiprfm49rhxjnl19r9in61xsz4i";
-            rev = "3fa7ccea4031a7424e77b63fd1f29e4d69b70b98";
+            sha256 = "1j3jys0ql62kd0dlpcd7c9i6ql4jw77n9lridyzwbyvcc2pw201b";
+            rev = "52969ff1e14385a9fa0e7de1593969f8b5e52a1b";
           };
           isLibrary = true;
           isExecutable = true;
           libraryHaskellDepends = [
+            aeson
             async
             attoparsec
             base
@@ -5625,6 +5703,7 @@ self: {
             deepseq
             ekg
             ekg-core
+            ether
             exceptions
             formatting
             hashable
@@ -5649,6 +5728,7 @@ self: {
             time-units
             transformers
             transformers-base
+            transformers-lift
             universum
             unordered-containers
             vector
@@ -7914,6 +7994,8 @@ self: {
           pname = "time-parsers";
           version = "0.1.2.0";
           sha256 = "091wpcqj1kjvyjgj1y1invn0g5lhdxc92az2bcbwbrpq2c7x8l2f";
+          revision = "1";
+          editedCabalFile = "f2a522da59c7dab618b37126dcd5e183658e0d46e13c7a56243b10b1541873bb";
           libraryHaskellDepends = [
             base
             parsers
@@ -8189,8 +8271,8 @@ self: {
       universum = callPackage ({ base, bytestring, containers, deepseq, exceptions, ghc-prim, hashable, microlens, microlens-mtl, mkDerivation, mtl, safe, stdenv, stm, text, text-format, transformers, type-operators, unordered-containers, utf8-string, vector }:
       mkDerivation {
           pname = "universum";
-          version = "0.4.2";
-          sha256 = "1chyj0mrrfhzhd6wrj9wlxyil9jiyq6yvk27dvh6qzj7qrw2ilzz";
+          version = "0.4.3";
+          sha256 = "17rrikfid54z8h95qns5q7bdxadnnggv1pl2d9ilz9pz9hi7a9g6";
           libraryHaskellDepends = [
             base
             bytestring
@@ -8583,6 +8665,30 @@ self: {
           doHaddock = false;
           doCheck = false;
           description = "Deriver for Data.Vector.Unboxed using Template Haskell";
+          license = stdenv.lib.licenses.bsd3;
+        }) {};
+      versions = callPackage ({ base, either, megaparsec, microlens, mkDerivation, semigroups, stdenv, tasty, tasty-hunit, text }:
+      mkDerivation {
+          pname = "versions";
+          version = "3.0.0";
+          sha256 = "0f7wvsjavv9hkrm5pgwg99w78apsqbrw4hk559cww83k3bbbg3j6";
+          libraryHaskellDepends = [
+            base
+            megaparsec
+            semigroups
+            text
+          ];
+          testHaskellDepends = [
+            base
+            either
+            microlens
+            tasty
+            tasty-hunit
+            text
+          ];
+          doHaddock = false;
+          doCheck = false;
+          description = "Types and parsers for software version numbers";
           license = stdenv.lib.licenses.bsd3;
         }) {};
       void = callPackage ({ base, mkDerivation, stdenv }:

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -762,8 +762,6 @@ self: {
           pname = "authenticate-oauth";
           version = "1.6";
           sha256 = "0xc37yql79r9idjfdhzg85syrwwgaxggcv86myi6zq2pzl89yvfj";
-          revision = "1";
-          editedCabalFile = "ba9e93e7b949fa4799ae7b3cb302df38dc7fb0be0460803b6c48636317b2bcbb";
           libraryHaskellDepends = [
             base
             base64-bytestring
@@ -1431,8 +1429,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           isLibrary = true;
           isExecutable = true;
@@ -1623,7 +1621,6 @@ self: {
             bytestring
             cardano-sl-core
             cardano-sl-infra
-            cardano-sl-lrc
             cardano-sl-ssc
             cardano-sl-txp
             cardano-sl-update
@@ -1688,8 +1685,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1762,8 +1759,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/db; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1800,8 +1797,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/godtossing; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1848,8 +1845,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/infra; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1910,8 +1907,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/lrc; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1940,8 +1937,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/ssc; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -1977,8 +1974,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/txp; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -2023,8 +2020,8 @@ self: {
           version = "0.4.4";
           src = fetchgit {
             url = "https://github.com/input-output-hk/cardano-sl.git";
-            sha256 = "1li70k82mvyn4psmwcjjdhvcbrdliq0mcxx3g7q8r1cpam77c27k";
-            rev = "4bcf1e6b601d531f753ebdb6aec23e19d4b08e6c";
+            sha256 = "05zk3bm27lmcfi2a93c70r3s0z79ah31j3zkib52arm5y15yh55h";
+            rev = "1239a6a876fbbb970e836c8bc6bb72d781ba2fa9";
           };
           postUnpack = "sourceRoot+=/update; echo source root reset to \$sourceRoot";
           libraryHaskellDepends = [
@@ -5174,8 +5171,6 @@ self: {
           pname = "memory";
           version = "0.14.5";
           sha256 = "01d1bg8pkhw9mpyd7nm5zzpqv9kh9cj2fkd2ywvkay7np2r14820";
-          revision = "1";
-          editedCabalFile = "fe81cc9b260784b0e8e71d4953441fc97a575200732ded56ce25c0900744e605";
           libraryHaskellDepends = [
             base
             bytestring
@@ -8194,8 +8189,8 @@ self: {
       universum = callPackage ({ base, bytestring, containers, deepseq, exceptions, ghc-prim, hashable, microlens, microlens-mtl, mkDerivation, mtl, safe, stdenv, stm, text, text-format, transformers, type-operators, unordered-containers, utf8-string, vector }:
       mkDerivation {
           pname = "universum";
-          version = "0.4.3";
-          sha256 = "17rrikfid54z8h95qns5q7bdxadnnggv1pl2d9ilz9pz9hi7a9g6";
+          version = "0.4.2";
+          sha256 = "1chyj0mrrfhzhd6wrj9wlxyil9jiyq6yvk27dvh6qzj7qrw2ilzz";
           libraryHaskellDepends = [
             base
             bytestring

--- a/pkgs/stack2nix.nix
+++ b/pkgs/stack2nix.nix
@@ -1,24 +1,24 @@
-{ mkDerivation, async, base, bytestring, containers, data-fix
-, directory, fetchgit, filepath, Glob, hnix, monad-parallel
-, optparse-applicative, process, SafeSemaphore, stdenv, temporary
-, text, yaml
+{ mkDerivation, async, base, bytestring, Cabal, containers
+, data-fix, directory, fetchgit, filepath, Glob, hnix
+, monad-parallel, optparse-applicative, process, SafeSemaphore
+, stdenv, temporary, text, yaml
 }:
 mkDerivation {
   pname = "stack2nix";
-  version = "0.1.0.0";
+  version = "0.1.2.0";
   src = fetchgit {
     url = "https://github.com/input-output-hk/stack2nix.git";
-    sha256 = "1vc8w9b7i4wr1jx5zj7kvxj1901ck15scj3556h8j8c64g6ppr8k";
-    rev = "8f087b92f83be078e8cfe86fb243121dca4601ba";
+    sha256 = "076rsasis3vxbfrp5r3aar4yz9qcrawy8hysvbix62823w12lfas";
+    rev = "3f2d4d31b1936dda71ce9a3be145c6407685045e";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    async base bytestring containers data-fix directory filepath Glob
-    hnix monad-parallel process SafeSemaphore temporary text yaml
+    async base bytestring Cabal containers data-fix directory filepath
+    Glob hnix monad-parallel process SafeSemaphore temporary text yaml
   ];
-  executableHaskellDepends = [ base optparse-applicative ];
+  executableHaskellDepends = [ base Cabal optparse-applicative ];
   doCheck = false;
   description = "Convert stack.yaml files into Nix build instructions.";
-  license = stdenv.lib.licenses.bsd3;
+  license = stdenv.lib.licenses.mit;
 }

--- a/pkgs/stack2nix.nix
+++ b/pkgs/stack2nix.nix
@@ -1,24 +1,24 @@
-{ mkDerivation, async, base, bytestring, Cabal, containers
-, data-fix, directory, fetchgit, filepath, Glob, hnix
-, monad-parallel, optparse-applicative, process, SafeSemaphore
-, stdenv, temporary, text, yaml
+{ mkDerivation, async, base, bytestring, containers, data-fix
+, directory, fetchgit, filepath, Glob, hnix, monad-parallel
+, optparse-applicative, process, SafeSemaphore, stdenv, temporary
+, text, yaml
 }:
 mkDerivation {
   pname = "stack2nix";
-  version = "0.1.2.0";
+  version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/input-output-hk/stack2nix.git";
-    sha256 = "076rsasis3vxbfrp5r3aar4yz9qcrawy8hysvbix62823w12lfas";
-    rev = "3f2d4d31b1936dda71ce9a3be145c6407685045e";
+    sha256 = "01b8kc205m6p2q3l4an0gx9062w9szjkk139m3qnra7g4bh5551g";
+    rev = "59ee4de0223da8ad8ae56adb02f39ec365a20d42";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    async base bytestring Cabal containers data-fix directory filepath
-    Glob hnix monad-parallel process SafeSemaphore temporary text yaml
+    async base bytestring containers data-fix directory filepath Glob
+    hnix monad-parallel process SafeSemaphore temporary text yaml
   ];
-  executableHaskellDepends = [ base Cabal optparse-applicative ];
+  executableHaskellDepends = [ base optparse-applicative ];
   doCheck = false;
   description = "Convert stack.yaml files into Nix build instructions.";
-  license = stdenv.lib.licenses.mit;
+  license = stdenv.lib.licenses.bsd3;
 }

--- a/scripts/check-stack2nix.sh
+++ b/scripts/check-stack2nix.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -xe
+
+# Get relative path to script directory
+scriptDir=$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")
+
+source ${scriptDir}/../pkgs/generate.sh
+
+git diff --text --exit-code

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,6 @@
 , nixpkgs  ? lib.fetchNixPkgs
 , pkgs     ? import nixpkgs {}
 , iohkpkgs ? import ./default.nix { inherit pkgs; }
-, stack2nix ? iohkpkgs.callPackage ./pkgs/stack2nix.nix {}
 }: let
 
 compiler      = pkgs.haskell.packages."${ghcVer}";
@@ -24,8 +23,6 @@ ghc           = ghcOrig.override (oldArgs: {
   in with new; parent // {
       # intero         = overGithub  old.intero "commercialhaskell/intero"
       #                  "e546ea086d72b5bf8556727e2983930621c3cb3c" "1qv7l5ri3nysrpmnzfssw8wvdvz0f6bmymnz1agr66fplazid4pn" { doCheck = false; };
-      inherit stack2nix;
-      iohk-ops       = iohkpkgs.callPackage (import ./iohk) {};
     };
   });
 
@@ -59,6 +56,6 @@ mkDerivation {
   license      = stdenv.lib.licenses.mit;
 };
 
-drv = ghc.callPackage drvf {};
+drv = pkgs.haskellPackages.callPackage drvf { inherit (iohkpkgs) stack2nix iohk-ops; };
 
 in if pkgs.lib.inNixShell then drv.env else drv

--- a/stack2nix-src.json
+++ b/stack2nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/stack2nix.git",
-  "rev": "3f2d4d31b1936dda71ce9a3be145c6407685045e",
-  "date": "2017-06-25T08:01:38-07:00",
-  "sha256": "076rsasis3vxbfrp5r3aar4yz9qcrawy8hysvbix62823w12lfas",
+  "rev": "59ee4de0223da8ad8ae56adb02f39ec365a20d42",
+  "date": "2017-06-16T14:08:22-07:00",
+  "sha256": "01b8kc205m6p2q3l4an0gx9062w9szjkk139m3qnra7g4bh5551g",
   "fetchSubmodules": true
 }


### PR DESCRIPTION
found an edgecase in testing this, updating `pkgs/default.nix` changes the build of stack2nix, and now travis cant use the cached copy, so it needs a PR built by hydra