### PR TITLE
optimize the systemd unit

### DIFF
--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -178,6 +178,13 @@ in {
       description   = "cardano node service";
       after         = [ "network.target" ];
       wantedBy = optionals cfg.autoStart [ "multi-user.target" ];
+      script = let
+        keyId = "key" + toString (cfg.testIndex + 1);
+        key = keyId + ".sk";
+      in ''
+        [ -f /run/keys/${keyId} ] && cp /run/keys/${keyId} ${stateDir}${key}
+        exec ${command}
+      '';
       serviceConfig = {
         User = "cardano-node";
         Group = "cardano-node";
@@ -189,14 +196,6 @@ in {
         KillSignal = "SIGINT";
         WorkingDirectory = stateDir;
         PrivateTmp = true;
-        ExecStart = let
-            keyId = "key" + toString (cfg.testIndex + 1);
-            key = keyId + ".sk";
-          in pkgs.writeScript "cardano-node.sh" ''
-          #!/bin/sh
-          [ -f /run/keys/${keyId} ] && cp /run/keys/${keyId} ${stateDir}${key}
-          exec ${command}
-        '';
       };
     };
   };


### PR DESCRIPTION
nixos can already create a script to do what cardano-node was doing, and it makes the logs more readable as well

```
Jun 29 13:04:54 amd-nixos kvz0yn3vgy23vb79d3f5j2v2wbqnkmp9-cardano-node.sh[26368]: [node:DEBUG:ThreadId 34] [2017-06-29 13:04:54 ADT] waiting for [] outbound inbound
Jun 29 13:04:54 amd-nixos kvz0yn3vgy23vb79d3f5j2v2wbqnkmp9-cardano-node.sh[26368]: [*production*.transport:ERROR:ThreadId 18] [2017-06-29 13:04:54 ADT] Exception in tcp server: thread killed
Jun 29 13:04:54 amd-nixos systemd[1]: Stopped cardano node service.
Jun 29 13:04:55 amd-nixos systemd[1]: Started cardano node service.
Jun 29 13:04:55 amd-nixos cardano-node-start[10691]: [Attention] We are in PRODUCTION mode
Jun 29 13:04:55 amd-nixos cardano-node-start[10691]: [Attention] Web-mode is on
Jun 29 13:04:55 amd-nixos cardano-node-start[10691]: [Attention] Wallet-mode is on
Jun 29 13:04:55 amd-nixos cardano-node-start[10691]: [node:INFO:ThreadId 11] [2017-06-29 13:04:55 ADT] Generating dht key..
```