### PR TITLE
[DEVOPS-194]  Fix scripts/aws.hs impurities:  make awscli specified as input

### DIFF
--- a/iohk/default.nix
+++ b/iohk/default.nix
@@ -1,6 +1,7 @@
 { mkDerivation, aeson, base, bytestring, cassava, containers, lens
 , lens-aeson, mtl, optional-args, safe, stdenv, system-filepath
 , text, turtle, utf8-string, vector, yaml
+, awscli, nix-prefetch-scripts, wget
 }:
 mkDerivation {
   pname = "iohk-ops";
@@ -12,6 +13,7 @@ mkDerivation {
     aeson base bytestring cassava containers lens lens-aeson mtl
     optional-args safe system-filepath text turtle utf8-string vector
     yaml
+    awscli nix-prefetch-scripts wget
   ];
   license = stdenv.lib.licenses.bsd3;
 }

--- a/scripts/aws.hs
+++ b/scripts/aws.hs
@@ -1,6 +1,4 @@
-#!/usr/bin/env nix-shell
-#! nix-shell -j 4 -i runhaskell -p 'pkgs.haskellPackages.ghcWithPackages (hp: with hp; [ turtle ])'
-#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/f2c4af4e3bd9ecd4b1cf494270eae5fd3ca9e68c.tar.gz
+#!/usr/bin/env runhaskell
 
 {-# LANGUAGE OverloadedStrings, UnicodeSyntax #-}
 

--- a/shell.nix
+++ b/shell.nix
@@ -31,9 +31,10 @@ ghc           = ghcOrig.override (oldArgs: {
 ###
 drvf =
 { mkDerivation, stdenv
-,   aeson, base, cassava, jq, lens-aeson, nix-prefetch-git, safe, turtle, utf8-string, vector, yaml
+,   aeson, base, cassava, jq, lens-aeson, safe, turtle, utf8-string, vector, yaml
+### non-haskell
 ,   stack2nix, cabal2nix, cabal-install, intero
-,   iohk-ops
+,   iohk-ops, awscli, nix-prefetch-scripts, wget
 }:
 mkDerivation {
   pname = "iohk-shell-env";
@@ -43,10 +44,11 @@ mkDerivation {
   isExecutable = true;
   doHaddock = false;
   executableHaskellDepends = [
-    aeson  base  cassava  jq  lens-aeson  nix-prefetch-git  safe  turtle  utf8-string  vector  yaml
+    aeson  base  cassava  jq  lens-aeson  safe  turtle  utf8-string  vector  yaml
+### non-haskell
     stack2nix  cabal2nix  cabal-install  intero
     pkgs.stack
-    iohk-ops
+    iohk-ops  awscli  nix-prefetch-scripts  wget
   ];
   shellHook =
   ''


### PR DESCRIPTION
Tested on the `daedalus-installer-test` bucket.

https://issues.serokell.io/issue/DEVOPS-195#comment=96-5415